### PR TITLE
Update to build with 64-bit SML/NJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 *.exe
 *.il
 bin/smlnet.x86-linux
+bin/smlnet.amd64-linux
 bin/v2.0-api

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Status
 ------
 
 This project has been updated to compile
-and build the demos with 64-bit SML/NJ 2025.1.
+and build the demos with modern 64-bit SML/NJ
+(> 2025.1, currently on the master branch only).
 In order to use the legacy 32-bit SML/NJ versions,
 use the `legacy` branch instead.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ to .NET libraries.
 Status
 ------
 
-This  project  is  now defunct  and  what  follows
-applies  to the  last  stable release  as of  2006
-which is also the state of the current tree.
+This project has been updated to compile
+and build the demos with 64-bit SML/NJ 2025.1.
+In order to use the legacy 32-bit SML/NJ versions,
+use the `legacy` branch instead.
 
 This distribution only supports  the 2.0 and lower
 versions  of  the  Microsoft  .NET  Framework  and
@@ -53,7 +54,17 @@ Warning: if the SML.NET compiled versions of
 Windows style line endings. So you should run
 `dos2unix` on `.lex` and `.grm` files first.
 
-To build SML.NET on Linux, first run `bld/buildsmlnet.sh`.
+To build SML.NET on Linux, first run
+`bld/buildsmlnet.sh`. Then go into the demos and
+either run it with a smlnet file like
+`bin/smlnet.sh @File` where there is a
+`File.smlnet` file in the directory, or
+`bin/smlnet.sh File` where there is a `File.sml`
+file in the directory. This should create an
+`.exe` file that can be ran with
+`mono program.exe`. In some demos, you may need
+to run `buildclient.sh` after building the
+smlnet file in order to produce an `.exe` file.
 
 Features
 --------

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Warning: if the SML.NET compiled versions of
 Windows style line endings. So you should run
 `dos2unix` on `.lex` and `.grm` files first.
 
+To build SML.NET on Linux, first run `bld/buildsmlnet.sh`.
+
 Features
 --------
 

--- a/bin/smlnet.sh
+++ b/bin/smlnet.sh
@@ -1,1 +1,1 @@
-sml -32 @SMLload=$SMLNETPATH/bin/smlnet.x86-linux $@
+sml @SMLload=$SMLNETPATH/bin/smlnet.amd64-linux $@

--- a/bld/buildsmlnet.sh
+++ b/bld/buildsmlnet.sh
@@ -1,1 +1,1 @@
-ml-build -32 $SMLNETPATH/src/sources.cm TopLevel.entry $SMLNETPATH/bin/smlnet
+ml-build $SMLNETPATH/src/sources.cm TopLevel.entry $SMLNETPATH/bin/smlnet

--- a/src/common/graph/Graph.sml
+++ b/src/common/graph/Graph.sml
@@ -46,7 +46,7 @@ struct
       node.  internal nodes are a tuple of a node label and an arc list.
       *)
 
-   structure IBM=IntBinaryMap (* this is just an abbreviation *)
+   structure IBM=IntRedBlackMap (* this is just an abbreviation *)
 
    datatype node=N of int
 

--- a/src/common/sources.cm
+++ b/src/common/sources.cm
@@ -15,7 +15,7 @@ Group
    signature RTINT (* Java integers *)
    structure RTInt
    signature RTLONG (* Java longs *)
-   structure RTLong 
+   structure RTLong
    signature JAVAINTINF (* Java BigIntegers *)
    structure JavaIntInf
    signature NUMOPS (* Operations on Java integers and Java longs *)
@@ -27,7 +27,7 @@ Group
    structure RTFloat
    signature RTDOUBLE (* Java doubles (64 bit reals) *)
    structure RTDouble
-   signature PACKABLE 
+   signature PACKABLE
    (* Signature of structures in RTInt,RTLong,UString,RTFloat and
       RTDouble which represent these as Word8Vectors. *)
    structure IntConvFlags
@@ -58,15 +58,15 @@ Group
 is
    $/smlnj-lib.cm
    $/basis.cm
-   
+
    (* class handles *)
    handles/CLASSHANDLE.sig
    handles/ClassHandle.sml
-   
+
 (* Runtime types and constants *)
    typesconsts/CONSTANTS.sig
    typesconsts/Constants.sml
-   typesconsts/TYPES.sig 
+   typesconsts/TYPES.sig
    typesconsts/Types.sml
 
 (* Runtime values and code for converting them to and from various
@@ -74,7 +74,7 @@ is
    values/RTINT.sig
    values/RTInt.sml
    values/RTLONG.sig
-   values/RTLong.sml 
+   values/RTLong.sml
    values/JAVAINTINF.sig
    values/JavaIntInf.sml
 
@@ -82,7 +82,7 @@ is
    values/REP16.sig (* Rep16:NUMOPS->REP16s is used to represent
                        Java integers and longs as lists of ordinary
                        ML integers *)
-   values/Rep16.sml   
+   values/Rep16.sml
    values/USTRING.sig (* Java strings *)
    values/UString.sml
    values/UCHAR.sig (* Classifies Unicode characters *)
@@ -91,7 +91,7 @@ is
    values/RTFloat.sml
    values/RTDOUBLE.sig (* Java doubles (64 bit reals) *)
    values/RTDouble.sml
-   values/PACKABLE.sig 
+   values/PACKABLE.sig
    (* Signature of structures in RTInt,RTLong,UString,RTFloat and
       RTDouble which represent these as Word8Vectors. *)
    values/IntConvFlags.sml
@@ -111,7 +111,8 @@ is
    values/INTOPS.sig
    values/MULCARRY.sig
    values/MulCarry.sml
-   
+   values/MulCarryLong.sml
+
    values/PACKFLOAT.sig (* Used internally for packing reals in Word8Vectors *)
    values/PackFloat.sml
    values/UNPACKFLOAT.sig (* Used internally for unpacking reals from
@@ -128,7 +129,7 @@ is
    (* The structures in utils are used by other code in this sources.cm
       file but are also used by the backend *)
    utils/ASSERT.sig (* Used for reporting errors when decoding
-                             classfiles and unpacking values from 
+                             classfiles and unpacking values from
                              Word8Vectors *)
    utils/Assert.sml
    utils/NUMBERS.sig (* Used for encoding numbers as Word8Vectors *)
@@ -144,8 +145,8 @@ is
 
    utils/SYMBOL.sig (* Implements symbols for the compiler *)
    utils/Symbol.sml
-   utils/GeneralSymbol.sml 
-                
+   utils/GeneralSymbol.sml
+
    utils/RESERVED.sig
    utils/Reserved.sml
 

--- a/src/common/utils/GeneralSymbol.sml
+++ b/src/common/utils/GeneralSymbol.sml
@@ -1,9 +1,9 @@
 (* Symbols are hashed UStrings which support fast equality testing
    and hashing.  We keep a record of all the symbols made so far so
-   that we don't have to make them again. 
+   that we don't have to make them again.
 
    WARNING.  Symbols will not work in a multi-threaded environment
-   unless it is revised and locks put in at critical sections. 
+   unless it is revised and locks put in at critical sections.
    *)
 structure GeneralSymbol:>SYMBOL=
 struct
@@ -19,7 +19,7 @@ struct
    type symbol=int
 
    (* Initial sizes of the string array and the hash table.
-      These are both made pretty big since rehashing is expensive. 
+      These are both made pretty big since rehashing is expensive.
       *)
    val initial_stringarr_size=8192
    val initial_hash_size=8192 (* This should be a power of 2 *)
@@ -45,7 +45,7 @@ struct
       let
          val slot= !next_slot
       in
-          if slot < Array.length(!stringarr) 
+          if slot < Array.length(!stringarr)
           then
               (Array.update(!stringarr,slot,js);
                next_slot:=slot+1;
@@ -84,7 +84,7 @@ struct
          val highbit=(Word.fromInt size) div 0w2
          val highbiti=Word.toInt highbit
 
-         fun part(f,x)= 
+         fun part(f,x)=
          (* Like List.partition but without currying or list reversal *)
          let
             fun partit(asf,bsf,[])=(asf,bsf)
@@ -134,11 +134,11 @@ struct
                          (* The element is not there.  Add it. *)
                          let
                              val index=insert js
-                         in 
-                             if index >= 0 
+                         in
+                             if index >= 0
                              then
                                  (* We put the new element at the head of the list.
-                                    Since elements are often used together, this may well 
+                                    Since elements are often used together, this may well
                                     be a good idea. *)
                                  (Array.update(tab,hash,index::l);
                                  index)
@@ -160,7 +160,7 @@ struct
          val fullhash=UString.hashAsciiStringSlice slice
          val hash=Word.toInt(Word.andb(!mask,fullhash))
          val tab= !table
-      in 
+      in
           if hash < Array.length(tab)
           then
               let
@@ -169,11 +169,11 @@ struct
                       (* The element is not there.  Add it. *)
                          let
                              val index=insert(UString.fromAsciiStringSlice slice)
-                         in 
-                             if index >= 0 
+                         in
+                             if index >= 0
                              then
                                  (* We put the new element at the head of the list.
-                                    Since elements are often used together, this may well 
+                                    Since elements are often used together, this may well
                                     be a good idea. *)
                                  (Array.update(tab,hash,index::l);
                                  index)
@@ -213,7 +213,7 @@ struct
 
 
       fun bucketSizes()=
-      let 
+      let
          val tab= !table
       in
          List.tabulate(Array.length tab,fn i=>length(Array.sub(tab,i)))
@@ -237,7 +237,7 @@ struct
    end
 
    structure Map:>ORD_MAP where type Key.ord_key=symbol = IntBinaryMap
-   structure Set:>ORD_SET where type Key.ord_key=symbol = IntBinarySet
+   structure Set:>ORD_SET where type Key.ord_key=symbol = IntRedBlackSet
 
    val equal=op=
    fun number i=i

--- a/src/common/utils/GeneralSymbol.sml
+++ b/src/common/utils/GeneralSymbol.sml
@@ -236,7 +236,7 @@ struct
       val compare=Int.compare
    end
 
-   structure Map:>ORD_MAP where type Key.ord_key=symbol = IntBinaryMap
+   structure Map:>ORD_MAP where type Key.ord_key=symbol = IntRedBlackMap
    structure Set:>ORD_SET where type Key.ord_key=symbol = IntRedBlackSet
 
    val equal=op=

--- a/src/common/utils/NUMBERS.sig
+++ b/src/common/utils/NUMBERS.sig
@@ -32,14 +32,17 @@ sig
    val i1:int->Word8.word
    val i2:int->Word8Vector.vector
    val i4:int->Word8Vector.vector
+   val i8:int->Word8Vector.vector
 
    val isi1:int->bool
    val isi2:int->bool
    val isi4:int->bool
+   val isi8:int->bool
 
    val I1:Int32.int->Word8.word
    val I2:Int32.int->Word8Vector.vector
    val I4:Int32.int->Word8Vector.vector
+   val I8:Int64.int->Word8Vector.vector
 
    val isI1:Int32.int->bool
    val isI2:Int32.int->bool
@@ -52,10 +55,12 @@ sig
    val isu1:int->bool
    val isu2:int->bool
    val isu4:int->bool
+   val isu8:int->bool
 
    val U1:Int32.int->Word8.word
    val U2:Int32.int->Word8Vector.vector
    val U4:Int32.int->Word8Vector.vector
+   val U8:Int64.int->Word8Vector.vector
 
    val isU1:Int32.int->bool
    val isU2:Int32.int->bool
@@ -64,13 +69,17 @@ sig
    val w1:Word.word->Word8.word
    val w2:Word.word->Word8Vector.vector
    val w4:Word.word->Word8Vector.vector
+   val w8:Word.word->Word8Vector.vector
 
    val W1:Word32.word->Word8.word
    val W2:Word32.word->Word8Vector.vector
    val W4:Word32.word->Word8Vector.vector
+   val W8:Word64.word->Word8Vector.vector
 
    val Log2:Int32.int->int option
    val WLog2:Word32.word->int option
+   val Log2':Int64.int->int option
+   val WLog2':Word64.word->int option
 
 (* unresolved handles will cause Fail("Unresolved Handle!") to be
    raised. *)

--- a/src/common/utils/Numbers.sml
+++ b/src/common/utils/Numbers.sml
@@ -31,6 +31,7 @@ structure Numbers:>NUMBERS=
 struct
 (* the primitive functions are the W?, w? and the is?? ones *)
    fun W1(w:Word32.word)=Word8.fromLargeWord(Word32.toLargeWord w)
+   fun W1'(w:Word64.word)=Word8.fromLargeWord(Word64.toLargeWord w)
    fun W2(w)=Word8Vector.fromList [
       W1(Word32.>>(w,0w8)),
       W1(w)
@@ -41,6 +42,16 @@ struct
       W1(Word32.>>(w,0w8)),
       W1(w)
       ]
+   fun W8(w:Word64.word)=Word8Vector.fromList [
+      W1'(Word64.>>(w,0w56)),
+      W1'(Word64.>>(w,0w48)),
+      W1'(Word64.>>(w,0w40)),
+      W1'(Word64.>>(w,0w32)),
+      W1'(Word64.>>(w,0w24)),
+      W1'(Word64.>>(w,0w16)),
+      W1'(Word64.>>(w,0w8)),
+      W1'(w)
+   ]
 
    fun w1(w:Word.word)=Word8.fromLargeWord(Word.toLargeWord w)
    fun w2(w)=Word8Vector.fromList [
@@ -53,15 +64,25 @@ struct
       w1(Word.>>(w,0w8)),
       w1(w)
       ]
+   fun w8(w)=Word8Vector.fromList [
+      w1(Word.~>>(w,0w56)),
+      w1(Word.>>(w,0w48)),
+      w1(Word.>>(w,0w40)),
+      w1(Word.>>(w,0w32)),
+      w1(Word.>>(w,0w24)),
+      w1(Word.>>(w,0w16)),
+      w1(Word.>>(w,0w8)),
+      w1(w)
+   ]
 
    val intbits=
    let
       val ex=Fail(
-"Sorry, Numbers.sml needs rewriting to handle integers with over 32 bits"
+"Sorry, Numbers.sml needs rewriting to handle integers with over 64 bits"
          )
    in
       case Int.precision of
-         SOME i => if i>=33 then raise ex else i
+         SOME i => if i>=65 then raise ex else i
       |  NONE   => raise ex
    end
    (* we assume isi4 and isu4 are always true *)
@@ -73,7 +94,8 @@ struct
 
    fun isi1(i)=i<=127 andalso i>= ~128
    fun isi2(i)=i<=32767 andalso i>= ~32768
-   fun isi4(i:int)=true
+   fun isi4(i)=i<=2147483647 andalso i>= ~2147483648
+   fun isi8(i:int)=true
 
    fun isI1(i:Int32.int)=i<=127 andalso i>= ~128
    fun isI2(i:Int32.int)=i<=32767 andalso i>= ~32768
@@ -81,7 +103,8 @@ struct
 
    fun isu1(i)=i<=255 andalso i>=0
    fun isu2(i)=i<=65535 andalso i>=0
-   fun isu4(i:int)=true
+   fun isu4(i:int)=i<=4294967295 andalso i>=0
+   fun isu8(i:int)=true
 
    fun isU1(i:Int32.int)=i<=255 andalso i>=0
    fun isU2(i:Int32.int)=i<=65535 andalso i>=0
@@ -92,14 +115,19 @@ struct
    fun i2(i)=w2(Word.fromInt(i))
    fun i4(i)=if isi4(i) then w4(Word.fromInt(i)) else
       raise Fail "Overflow in i4"
+   fun i8(i)=if isi8(i) then w8(Word.fromInt(i)) else
+      raise Fail "Overflow in i8"
    fun u1(i)=if isu1(i) then w1(Word.fromInt(i)) else
       raise Fail "Overflow in u1"
    fun u2(i)=if isu2(i) then w2(Word.fromInt(i)) else
       raise Fail "Overflow in u2"
    fun u4(i)=if isu4(i) then w4(Word.fromInt(i)) else
       raise Fail "Overflow in u4"
+   fun u8(i)=if isu8(i) then w8(Word.fromInt(i)) else
+      raise Fail "Overflow in u4"
 
    fun fromInt32 i=Word32.fromLargeInt(Int32.toLarge i)
+   fun fromInt64 i=Word64.fromLargeInt(Int64.toLarge i)
 
    fun I1(i)=if isI1(i) then W1(fromInt32(i)) else
       raise Fail "Overflow in I1"
@@ -107,12 +135,14 @@ struct
       raise Fail "Overflow in I2"
    fun I4(i)=if isI4(i) then W4(fromInt32(i)) else
       raise Fail "Overflow in I4"
+   fun I8(i)=W8(fromInt64(i))
    fun U1(i)=if isU1(i) then W1(fromInt32(i)) else
       raise Fail "Overflow in U1"
    fun U2(i)=if isU2(i) then W2(fromInt32(i)) else
       raise Fail "Overflow in U2"
    fun U4(i)=if isU4(i) then W4(fromInt32(i)) else
       raise Fail "Overflow in U4"
+   fun U8(i)=W8(fromInt64(i))
 
    fun h1(h)=u1(h{})
    fun h2(h)=u2(h{})
@@ -132,6 +162,22 @@ struct
       else
           NONE
    end
+   fun WLog2' w=if Word64.<=(w,0w0) then NONE
+   else
+   let
+      fun nbits(0w1,s)=s
+      |   nbits(w,s)=nbits(Word64.>>(w,0w1),s+1)
+   in
+      if Word64.andb(w,Word64.-(w,0w1))=0w0
+      then
+         (* it's a power of 2.  If you think this is yucky, count yourself
+            lucky I resisted the temptation to find nbits by table lookup
+            with index w rem 37! *)
+          SOME (nbits(w,0))
+      else
+          NONE
+   end
 
    fun Log2 i=WLog2(Word32.fromLargeInt(Int32.toLarge i))
+   fun Log2' i=WLog2'(Word64.fromLargeInt(Int64.toLarge i))
 end

--- a/src/common/values/MULCARRY.sig
+++ b/src/common/values/MULCARRY.sig
@@ -3,7 +3,8 @@
    *)
 signature MULCARRY=
 sig
+   type word
    (* In each case, the carry is given first *)
-   val mul10:Word32.word->Word32.word*Word32.word
-   val mul16:Word32.word->Word32.word*Word32.word
+   val mul10:word->word*word
+   val mul16:word->word*word
 end

--- a/src/common/values/MulCarry.sml
+++ b/src/common/values/MulCarry.sml
@@ -1,9 +1,10 @@
 (* MulCarry:MULCARRY implements multiplication by 10 and by 16 of Word32.words
    interpreted as an unsigned quantity with carry.
    *)
-structure MulCarry:>MULCARRY=
+structure MulCarry:>MULCARRY where type word = Word32.word =
 struct
    (* In each case, the carry is given first *)
+   type word = Word32.word
 
    fun mul10 (w:Word32.word)=
    let

--- a/src/common/values/MulCarryLong.sml
+++ b/src/common/values/MulCarryLong.sml
@@ -1,0 +1,26 @@
+(* MulCarryLong:MULCARRY implements multiplication by 10 and by 16 of Word64.words
+   interpreted as an unsigned quantity with carry.
+   *)
+structure MulCarryLong:>MULCARRY where type word = Word64.word=
+struct
+   (* In each case, the carry is given first *)
+   type word = Word64.word
+
+   fun mul10 (w:Word64.word)=
+   let
+      val mul=Word64.*(w,0w10)
+      (* mul is the remainder.  We need to compute the carry.  We know
+         that (for real integers) mul=10*w-2^32*carry.  Hence
+         *)
+      val carry=Word64.mod(Word64.<<(
+         Word64.+(Word64.mod(mul,0w11),Word64.mod(w,0w11)),
+         0w3)
+         ,0w11)
+      (* (3 remainders & an extra addition seem excessive but I can't be
+         bothered to think up a better way right now) *)
+   in
+      (carry,mul)
+   end
+
+   fun mul16 w=(Word64.>>(w,0w28),Word64.<<(w,0w4))
+end

--- a/src/common/values/RTLong.sml
+++ b/src/common/values/RTLong.sml
@@ -1,371 +1,145 @@
 structure RTLong:>RTLONG =
 struct
-   datatype t=P of Word32.word*Word32.word (* high one first *)
-  
-   val Zero=P(0w0,0w0)
-   val One=P(0w0,0w1)
+   type t=Int64.int
+   type pair = Word32.word * Word32.word (* high one first *)
 
-   val fromWordPair = P
-   fun toWordPair (P p) = p
+   fun fromWordPair (w1, w2) =
+      let
+         val w1 = Word32.toLarge w1
+         val w2 = Word32.toLarge w2
+      in
+         Int64.fromLarge (Word64.toLargeIntX (Word64.orb (Word64.<<(w1, 0w32), w2)))
+      end
+   fun toWordPair i =
+      let
+         val w = Word64.fromLargeInt (Int64.toLarge i)
+         fun conv (w:Word64.word) = Word32.fromLargeWord w
+      in
+         (conv (Word64.>> (w, 0w32)), conv w)
+      end
 
-   val W2i=Int32.fromLarge o Word32.toLargeIntX 
+   val W2i=Int32.fromLarge o Word32.toLargeIntX
    val i2w=Word.fromInt
 
    structure pack:>PACKABLE where type t=t =
    struct
       type t=t
-      fun pack(P(w1,w2))=
-         Word8Vector.concat[Numbers.W4(w1),Numbers.W4(w2)]
+      val pack = Numbers.I8
       fun equal(x,y)=x=y
    end
 
-   fun getlong is=P(ReadInts.W4 is,ReadInts.W4 is)
+   fun getlong is = fromWordPair (ReadInts.W4 is,ReadInts.W4 is)
 
-   fun log2 (P(w1,w2))=
-      (case (w1,w2) of
-         (0w0,w) => Numbers.WLog2(w)
-       | (w,0w0) =>
-          (case Numbers.WLog2(w) of
-             SOME s=>SOME(s+32)
-          |  NONE  =>NONE
-          )
-       | _       => NONE
-       )
+   val log2 = Numbers.Log2'
 
-   fun compare(P(high1,low1),P(high2,low2))=
-   let
-      val cmp = Word32.compare(high1,high2)
-   in
-      (case cmp of
-          EQUAL => Word32.compare(low1,low2)
-      |   _     => cmp
-      )
-   end
+   val compare = Int64.compare
 
-   structure numops:>NUMOPS where type num=t where type shiftnum=RTInt.t =
+   structure numops:>NUMOPS where type num=Int64.int
+      where type shiftnum=RTInt.t=
    struct
-      type num=t
+      type num=Int64.int
       type shiftnum=RTInt.t
-      fun W2w x=Word.fromLargeWord(Word32.toLargeWord x)
-   
-      val precision=2*Word32.wordSize
+
+      val precision=valOf(Int64.precision)
       exception NumOverflow
+      fun fromInt value=
+      if Numbers.isi8(value) then
+         Int64.fromInt(value)
+      else raise NumOverflow
 
-      val _ = if valOf(Int.precision)>Word32.wordSize
-              then raise Fail 
-"Please modify numops.fromInt and numops.toInt in RTLong.sml to cope with large integers."
-              else {}
+      fun toInt i=Int64.toInt i
+         handle Overflow => raise NumOverflow
 
-      fun fromInt value= (* The only difficulty is with the sign bit. . . *)
-      if(value>=0) then
-         P(0w0,Word32.fromLargeInt(Int.toLarge(value)))
+      val toShift = RTInt.fromInt
+
+      fun w2i w=Int64.fromLarge(Word64.toLargeIntX w)
+      fun i2w i=Word64.fromLargeInt(Int64.toLarge i)
+      fun i2w' i=Word64.fromLargeInt(Int32.toLarge i)
+      fun W2w x=Word.fromLargeWord(Word64.toLargeWord x)
+
+      fun deword f (x,y)= w2i(f(i2w x,i2w y))
+      val add=deword Word64.+
+      val sub=deword Word64.-
+      fun neg x=w2i(Word64.-(0w0,i2w x))
+
+      val mul=deword Word64.*
+      fun x div y=
+      if y=0 then NONE
       else
-         P(0wxffffffff,Word32.fromLargeInt(Int.toLarge(value)))
+         (SOME(Int64.quot(x,y)))
+         handle
+            Div => NONE (* division by 0 *)
+         |  Overflow => SOME x
+            (* Overflow can only occur when
+               ~2^32 is divided by ~1; for the
+               Java VM the result is 2^32 wrapped
+               around to get ~2^32 again *)
+      fun rem(x,y)=
+         (SOME(Int64.rem(x,y)))
+         handle
+            Div => NONE (* division by 0 *)
 
-      fun toInt(P(w1,w2))=(case w1 of
-         0w0         =>  ((Word32.toInt(w2)) handle Overflow => raise NumOverflow)
-      |  0wxffffffff => (let val i=Word32.toIntX(w2)
-   			 in if i<0 then i else raise NumOverflow
-   			 end handle Overflow => raise NumOverflow)
-      |  _   => raise NumOverflow
-      )
+      val andb=deword Word64.andb
+      val orb=deword Word64.orb
+      val xorb=deword Word64.xorb
 
-      val toShift=RTInt.numops.fromInt
+      fun get5bits x= W2w(Word64.andb(i2w' (RTInt.toInt32 x),0wx1f))
+      fun deword5 f (x,y)=w2i(f(i2w x,get5bits y))
+      val shl=deword5 Word64.<<
+      val shr=deword5 Word64.~>>
+      val ushr=deword5 Word64.>>
 
-      (* The code for this is the same as that for op-
-         except we drop the overflow test *)
-      fun sub(arg1 as P(high1,low1),arg2 as P(high2,low2))=
-      let
-         (* Do subtraction modulo 2^64 *)
-         val low=low1-low2
-         val borrow=if low1<low2 then 0w1 else 0w0
-         val high=high1-high2-borrow
-         val ans=P(high,low)
-      in
-         ans
-      end
-
-      fun neg(arg)=
-         sub(Zero,arg)
-
-      fun add(arg1 as P(high1,low1),arg2 as P(high2,low2))=
-      let
-         (* Do addition modulo 2^64 *)
-         val low=low1+low2
-         val carry=if low<low1 then 0w1 else 0w0
-         val high=high1+high2+carry
-         val ans=P(high,low)
-      in
-         ans
-      end
-
-      fun andb(arg1 as P(high1,low1),arg2 as P(high2,low2))=
-         P(Word32.andb(high1,high2),Word32.andb(low1,low2))
-    
-      fun orb(arg1 as P(high1,low1),arg2 as P(high2,low2))=
-         P(Word32.orb(high1,high2),Word32.orb(low1,low2))
- 
-      fun xorb(arg1 as P(high1,low1),arg2 as P(high2,low2))=
-         P(Word32.xorb(high1,high2),Word32.xorb(low1,low2))
-
-      val highbit=0wx80000000:Word32.word
-
-      val ji63=RTInt.fromInt 0x3f
-      fun get6bits (x):Word.word=
-         i2w(valOf(RTInt.toInt(RTInt.numops.andb(x,ji63))))
-
-
-      fun shl(P(A,B),ji)=
-      let
-         val N=get6bits ji
-      in
-         if N>=0w32 
-         then P(Word32.<<(B,N-0w32),0w0)
-         else P(Word32.orb(Word32.<<(A,N),Word32.>>(B,0w32-N)),Word32.<<(B,N))
-      end
- 
-      fun ushr(P(A,B),ji)=
-      let
-         val N=get6bits ji
-      in
-         if N>=0w32
-         then P(0w0,Word32.>>(A,N-0w32))
-         else P(Word32.>>(A,N),Word32.orb(Word32.<<(A,0w32-N),Word32.>>(B,N)))
-      end
- 
-      fun shr(P(A,B),ji)=
-      let
-         val N=get6bits ji
-      in
-         if N>=0w32
-         then P(Word32.~>>(A,N),Word32.~>>(A,N-0w32))
-         else P(Word32.~>>(A,N),Word32.orb(Word32.<<(A,0w32-N),Word32.>>(B,N)))
-      end
-
-      fun compare(P(h1,l1),P(h2,l2))=
-         (case Int32.compare(W2i h1,W2i h2) of
-            LESS => LESS
-         |  GREATER => GREATER
-         |  EQUAL => Word32.compare(l1,l2)
-         )
-     
-      val Compare=SOME o compare  
-
-      fun lt(a,b)=(compare(a,b)=LESS)      
+      val compare=Int64.compare
+      val Compare=SOME o compare
+      fun lt(a,b)=(compare(a,b)=LESS)
       fun le(a,b)=(compare(a,b)<>GREATER)
-
-      fun mul2(w1,w2)=
-      (* mul2 multiplies 2 32 bit words and returns the
-         64 bit word, as t *)
-      let
-         (* We do this by splitting the words into 16bit halves *)
-         fun low16 x=Word32.andb(x,0wxffff)
-         fun high16 x=Word32.>>(x,0w16)
-         fun shift16 x=P(high16 x,Word32.<<(low16 x,0w16))
-
-         val low1=low16 w1
-         val high1=high16 w1
-         val low2=low16 w2
-         val high2=high16 w2
-         val s1=P(Word32.*(high1,high2),Word32.*(low1,low2))
-         val s2=shift16(Word32.*(high1,low2))
-         val s3=shift16(Word32.*(low1,high2))
-      in
-         add(add(s1,s2),s3)
-      end   
-
-      fun mul(P(high1,low1),P(high2,low2))=
-      let
-         val P(higha1,low)=mul2(low1,low2)
-         val higha2=Word32.*(low1,high2)
-         val higha3=Word32.*(high1,low2)
-      in
-         P(Word32.+(Word32.+(higha1,higha2),higha3),low)
-      end
-
-      (* Do div and rem. *)
-      fun wordless(P(h1,l1),P(h2,l2))=
-         Word32.<(h1,h2) orelse h1=h2 andalso Word32.<(l1,l2)
-
-      val jl1=RTInt.fromInt 1
-      fun shl1(x)=shl(x,jl1)
-
-      (* The following algorithm is far slower but also 
-         far simpler than the alternative which involves using
-         Word32./ in various cunning ways to do long division (see Knuth) *)
-      fun quotrem(A,B)=
-      (* Find (quotient,remainder) of A/B, considered as
-         unsigned integers, where A<=2^63 *)
-         if wordless(A,B)
-         then (Zero,A)
-         else if A=B
-         then
-              (One,Zero)
-         else
-         let
-            (* B<A<=2^63.  Therefore the top bit of B is unset and
-               shl1 B is 2*B *)
-
-            val (quot',rem')=quotrem(A,shl1 B)
-            (* A= (2*quot')*B + rem'
-               where rem' is in [0,2*B) *)
-         in
-            if wordless(rem',B) 
-            then 
-               (shl1 quot',rem')
-            else
-               (add(shl1 quot',One),sub(rem',B))
-         end
-
-      fun sgnabs(a as P(h1,_))=
-      (* (true if negative),(absolute part as an unsigned integer) *)
-      let
-         val signed=Word32.>=(h1,highbit)
-      in
-         (signed,if signed then neg a else a)
-      end   
-      
-      fun A div B=
-      if B=Zero then NONE
-      else
-      SOME let
-         val (signA,absA)=sgnabs A
-         val (signB,absB)=sgnabs B
-         val (quot,rem)=quotrem(absA,absB)  
-      in
-         if signA=signB then quot else neg quot
-      end
-
-      fun rem(A,B)=
-      if B=Zero then NONE
-      else
-      SOME let
-         val (signA,absA)=sgnabs A
-         val (signB,absB)=sgnabs B
-         val (quot,rem)=quotrem(absA,absB)  
-      in
-         if signA then neg rem else rem
-      end
-   end (* numops *)     
+   end
 
    structure IntOps:>INTOPS where type t=t =
    struct
-
       type t=t
+      fun zero _ = 0:Int64.int
+      fun mul10 {signed=signed} (n:Int64.int)=
+         if signed
+         then n*10
+         else
+            let
+               val w=Word64.fromLargeInt(Int64.toLarge n)
+               val (carry,mul)=MulCarryLong.mul10 w
+            in
+               if carry=0w0
+               then Int64.fromLarge(Word64.toLargeIntX mul)
+               else raise Overflow
+            end
 
-      fun zero _ = Zero
-   (* NB mul10 and mul16 are almost entirely identical so don't change one
-      without considering the other. *)
+      fun mul16 {signed=signed} (n:Int64.int)=
+         if signed
+         then n*16
+         else
+            let
+               val w=Word64.fromLargeInt(Int64.toLarge n)
+               val (carry,mul)=MulCarryLong.mul16 w
+            in
+               if carry=0w0
+               then Int64.fromLarge(Word64.toLargeIntX mul)
+               else raise Overflow
+            end
 
-      fun mul10 {signed=signed} (P(high,low))=
-      let
-   	 (* do computation modulo 2^64 *)
-   	 val (lowcarry,lowans)=MulCarry.mul10 low
-   	 val (highcarry,highans1)=MulCarry.mul10 high
-   	 val highans=Word32.+(lowcarry,highans1)
-   	 val highcarry=
-	    if Word32.<(highans,highans1)
-	    then (* NB lowcarry is always in [0,9] *)
-		Word32.+(highcarry,0w1)
-	    else
-		highcarry
-   	 val overflow=
-            if signed
-            then
-	       if Word32.<(high,0wx80000000)
-	       then
-	    	  (highcarry<>0w0)
-	       else
-	    	  (highcarry<>0w9)
-            else
-               highcarry<>0w0
+      fun do_digit {signed=signed} (n:Int64.int,digit:int)=
+         if signed
+         then n-Int64.fromLarge(Int.toLarge digit)
+         else
+            let
+               val w=Word64.fromLargeInt(Int64.toLarge n)
+               val d=Word64.fromInt digit
+               val res=Word64.+(w,d)
+            in
+               if Word64.>=(res,w)
+               then Int64.fromLarge(Word64.toLargeIntX res)
+               else raise Overflow
+            end
 
-   	 val _=if overflow then raise Overflow else {}
-      in
-   	 P(highans,lowans)
-      end
-
-   (* NB mul10 and mul16 are almost entirely identical so don't change one
-      without considering the other. *)
-
-      fun mul16 {signed=signed} (P(high,low))=
-      let
-   	 (* do computation modulo 2^64 *)
-   	 val (lowcarry,lowans)=MulCarry.mul16 low
-   	 val (highcarry,highans1)=MulCarry.mul16 high
-   	 val highans=Word32.+(lowcarry,highans1)
-   	 val highcarry=
-	    if Word32.<(highans,highans1)
-	    then (* lowcarry is always in [0,15] *)
-		Word32.+(highcarry,0w1)
-	    else
-		highcarry
-   	 val overflow=
-            if signed
-            then
-	       if Word32.<(high,0wx80000000)
-	       then
-	    	  (highcarry<>0w0)
-	       else
-	    	  (highcarry<>0w15)
-            else
-               highcarry<>0w0
-
-   	 val _=if overflow then raise Overflow else {}
-      in
-   	 P(highans,lowans)
-      end
-
-      fun add_carry (x:Word32.word,y:Word32.word) =
-      (* adds two words and a pair (carry,result) *)
-      let
-         val res=x+y
-         val carry:Word32.word= if res >= x then 0w0 else 0w1
-      in
-         (carry,res)
-      end
-
-      fun addl_carry (P(xh,xl),y)=
-      (* adds y, which is considered signed,
-         to a 64-bit unsigned quantity and returns a pair (carry,result) *)
-      let
-         val (carryl,resl)=add_carry(xl,y)
-         val high_add=
-            Word32.-(
-               carryl,
-               if W2i(y)>=0 then 0w0 else 0w1
-               )
-         val (carryh,resh)=add_carry(xh,high_add)
-      in
-         (carryh,P(resh,resl))
-      end
-
-      fun do_digit {signed=signed} (x,digit:int)=
-      let
-         val to_add=
-            if signed
-            then Word32.fromInt(~digit)
-            else Word32.fromInt(digit)
-         val (carry,res)=addl_carry(x,to_add)
-         val overflow=
-            if signed then
-               numops.lt(x,res)
-            else
-               carry<>0w0
-         val _ = if overflow then raise Overflow else {}
-      in
-         res
-      end
-
-      fun neg (x as P(xh,xl))=
-      if xl = 0w0 andalso xh = 0wx80000000 then raise Overflow
-      else
-         let
-	    val compl=P(Word32.notb(xh),Word32.notb(xl))
-	    val (_,res as P(resh,resl))=addl_carry(compl,0w1)
-	 in
-	    res
-	 end
+      val neg=Int64.~
    end (* IntOps *)
 
    structure IC=IntConv(IntOps)
@@ -380,7 +154,7 @@ struct
       for this. *)
    structure RepInt=Rep16(RTInt.numops)
    structure RepLong=Rep16(numops)
- 
+
    fun toRTInt jl=
    let
       val int16s=RepLong.to16 jl
@@ -395,7 +169,7 @@ struct
       val int16s=RepInt.to16 ji
       val signed=(hd int16s>=0x8000)
       val extended_int16s=
-         (if signed 
+         (if signed
           then
             [0xffff,0xffff]
           else

--- a/src/front/entity/Entity.sml
+++ b/src/front/entity/Entity.sml
@@ -63,7 +63,7 @@ type FileRef = string * Time.time
 fun makeFileRef (s, t) =
 let
   val s =
-    if SMLofNJ.SysInfo.getOSKind() = SMLofNJ.SysInfo.WIN32
+    if SMLofNJ.SysInfo.getOSKind() = SMLofNJ.SysInfo.WINDOWS
     then String.map (fn #"/" => #"\\" | c => c) s
     else String.map (fn #"\\" => #"/" | c => c) s
 in

--- a/src/front/entity/Entity.sml
+++ b/src/front/entity/Entity.sml
@@ -63,7 +63,7 @@ type FileRef = string * Time.time
 fun makeFileRef (s, t) =
 let
   val s =
-    if SMLofNJ.SysInfo.getOSKind() = SMLofNJ.SysInfo.WINDOWS
+    if SMLofNJ.SysInfo.getOSKind() = SMLofNJ.SysInfo.WIN32
     then String.map (fn #"/" => #"\\" | c => c) s
     else String.map (fn #"\\" => #"/" | c => c) s
 in

--- a/src/front/entity/Entity.sml
+++ b/src/front/entity/Entity.sml
@@ -19,7 +19,7 @@ datatype Type = Sig | Str | Fun | FunSig | Assembly
 fun typeToInt Sig = 0
   | typeToInt Str = 1
   | typeToInt Fun = 2
-  | typeToInt FunSig = 3 
+  | typeToInt FunSig = 3
   | typeToInt Assembly = 4
 
 fun intToType 0 = Sig
@@ -37,10 +37,10 @@ type Ref = Type * Symbol.symbol
 (*----------------------------------------------------------------------*)
 (* Finite sets and maps for entity references				*)
 (*----------------------------------------------------------------------*)
-structure Ord = 
-  struct 
+structure Ord =
+  struct
     type ord_key = Ref
-    fun compare((t1,s1), (t2,s2)) = 
+    fun compare((t1,s1), (t2,s2)) =
       case Int.compare(typeToInt t1, typeToInt t2) of
         EQUAL => Symbol.Key.compare(s1, s2)
       | other => other
@@ -60,10 +60,10 @@ type FileRef = string * Time.time
 (* Create a fileref, translating forward slashes into the OS		*)
 (* path separator. Also convert relative file names into absolute ones. *)
 (*----------------------------------------------------------------------*)
-fun makeFileRef (s, t) = 
+fun makeFileRef (s, t) =
 let
-  val s = 
-    if SMLofNJ.SysInfo.getOSKind() = SMLofNJ.SysInfo.WIN32
+  val s =
+    if SMLofNJ.SysInfo.getOSKind() = SMLofNJ.SysInfo.WINDOWS
     then String.map (fn #"/" => #"\\" | c => c) s
     else String.map (fn #"\\" => #"/" | c => c) s
 in

--- a/src/front/mil/Var.sml
+++ b/src/front/mil/Var.sml
@@ -8,8 +8,8 @@ struct
 type Var = int
 type Supply = int
 
-structure Set = IntBinarySet
-structure Map = IntBinaryMap
+structure Set = IntRedBlackSet
+structure Map = IntRedBlackMap
 
 val dummy = 0
 fun isDummy v = v=0
@@ -18,7 +18,7 @@ fun fresh supply = (supply+1, supply)
 
 fun eq (v1:Var,v2:Var) = v1=v2
 
-fun extend (env, vs) = 
+fun extend (env, vs) =
   foldr (fn ((v,x),env) => Map.insert(env, v, x)) env vs
 
 fun toString v = if v=0 then "*" else Pretty.indexToString (v-1)
@@ -28,7 +28,7 @@ fun supplyIndex v = v
 fun fromInt i = i
 fun supplyFromInt i = i
 
-fun lookup (env, v) = 
+fun lookup (env, v) =
   case Map.find(env, v) of
     NONE => raise Fail ("Var.lookup: variable " ^ toString v ^ " not found")
   | SOME x => x


### PR DESCRIPTION
Updates `Numbers.sml` to allow for packing/unpacking of 64 bit integers and updates `RTLong.sml` to use an `Int64.int` instead of a tuple of `Word32.word`s. Most of the math is copied from `RTInt`'s ops and converted to `Int64` instead of `Int32`. Converts uses of `IntBinarySet` and `IntBinaryMap` into `IntRedBlackSet` and `IntRedBlackMap` because there seems to be a bug where the binary versions add the same value multiple times and intersection doesn't work properly.