### PR TITLE
Library and runtime changes to compile smlfmt and smlgen

### DIFF
--- a/lib/smlnj-lib/Util/hash-table-fn.sml
+++ b/lib/smlnj-lib/Util/hash-table-fn.sml
@@ -39,6 +39,31 @@ functor HashTableFn (Key : HASH_KEY) : MONO_HASH_TABLE =
   (* remove all elements from the table *)
     fun clear (HT{table, n_items, ...}) = (HTRep.clear(!table); n_items := 0)
 
+		fun insertWithi combine (tbl as HT{table, n_items, ...}) (key, item) = let
+	  val arr = !table
+	  val sz = Array.length arr
+	  val hash = hashVal key
+	  val indx = index (hash, sz)
+	  fun look HTRep.NIL = (
+		Array.update(arr, indx, HTRep.B(hash, key, item, Array.sub(arr, indx)));
+		n_items := !n_items + 1;
+		ignore (HTRep.growTableIfNeeded (table, !n_items));
+		HTRep.NIL)
+	    | look (HTRep.B(h, k, v, r)) = if ((hash = h) andalso sameKey(key, k))
+		then HTRep.B(hash, key, combine(k, v, item), r)
+		else (case (look r)
+		   of HTRep.NIL => HTRep.NIL
+		    | rest => HTRep.B(h, k, v, rest)
+		  (* end case *))
+	  in
+	    case (look (Array.sub (arr, indx)))
+	     of HTRep.NIL => ()
+	      | b => Array.update(arr, indx, b)
+	    (* end case *)
+	  end
+
+    fun insertWith combine = insertWithi (fn (_, v1, v2) => combine(v1, v2))
+
   (* Insert an item.  If the key already has an item associated with it,
    * then the old item is discarded.
    *)

--- a/lib/smlnj-lib/Util/int-hash-table.sml
+++ b/lib/smlnj-lib/Util/int-hash-table.sml
@@ -44,6 +44,32 @@ structure IntHashTable :> MONO_HASH_TABLE where type Key.hash_key = int =
   (* remove all elements from the table *)
     fun clear (HT{table, n_items, ...}) = (HTRep.clear(!table); n_items := 0)
 
+		fun insertWithi combine (tbl as HT{table, n_items, ...}) (key, item) = let
+	  val arr = !table
+	  val sz = Array.length arr
+	  val hash = hashVal key
+	  val indx = index (hash, sz)
+	  fun look HTRep.NIL = (
+		Array.update(arr, indx, HTRep.B(hash, key, item, Array.sub(arr, indx)));
+		n_items := !n_items + 1;
+		ignore (HTRep.growTableIfNeeded (table, !n_items));
+		HTRep.NIL)
+	    | look (HTRep.B(h, k, v, r)) = if (hash = h)
+		then HTRep.B(hash, key, combine(k, v, item), r)
+		else (case (look r)
+		   of HTRep.NIL => HTRep.NIL
+		    | rest => HTRep.B(h, k, v, rest)
+		  (* end case *))
+	  in
+	    case (look (Array.sub (arr, indx)))
+	     of HTRep.NIL => ()
+	      | b => Array.update(arr, indx, b)
+	    (* end case *)
+	  end
+
+    fun insertWith combine = insertWithi (fn (_, v1, v2) => combine(v1, v2))
+
+
   (* Insert an item.  If the key already has an item associated with it,
    * then the old item is discarded.
    *)

--- a/lib/smlnj-lib/Util/mono-hash-table-sig.sml
+++ b/lib/smlnj-lib/Util/mono-hash-table-sig.sml
@@ -25,6 +25,12 @@ signature MONO_HASH_TABLE =
     val clear : 'a hash_table -> unit
 	(* remove all elements from the table *)
 
+    val insertWith  : ('a * 'a -> 'a) -> 'a hash_table -> Key.hash_key * 'a -> unit
+    val insertWithi : (Key.hash_key * 'a * 'a -> 'a)
+          -> 'a hash_table
+          -> Key.hash_key * 'a
+          -> unit
+
     val insert : 'a hash_table -> (Key.hash_key * 'a) -> unit
 	(* Insert an item.  If the key already has an item associated with it,
 	 * then the old item is discarded.

--- a/src/basis/ArraySlice.sml
+++ b/src/basis/ArraySlice.sml
@@ -1,8 +1,8 @@
 structure ArraySlice :> ARRAY_SLICE =
 struct
 
-local 
-  open General Option PrimUtils_.Int 
+local
+  open General Option PrimUtils_.Int
 in
 
 type 'a slice = 'a array * int * int
@@ -22,28 +22,31 @@ fun vector sl = Vector.tabulate (length sl, fn i => sub (sl, i))
 fun isEmpty ((a,i,0):'a slice) = true
   | isEmpty _ = false
 
-fun subslice ((a,i,n),j,mopt) = raise General.Fail "ArraySlice.subslice not implemented yet"
+fun subslice ((a,i,n),j,NONE) =
+      if j < 0 orelse n < j then raise Subscript else (a, i+j, n-j)
+  | subslice ((a,i,n),j,SOME k) =
+      if j < 0 orelse k < 0 orelse n < j+k then raise Subscript else (a, i+j, k)
 
-fun foldli f e (slice as (a, i, n)) = 
+fun foldli f e (slice as (a, i, n)) =
     let fun loop stop =
-	    let fun lr j res = 
+	    let fun lr j res =
 		if j < stop then lr (j+1) (f(j, Array.sub(a,j), res))
 		else res
 	    in lr i e end
     in loop (i+n) end
 
-fun foldri f e (slice as (a, i, n)) = 
+fun foldri f e (slice as (a, i, n)) =
     let fun loop start =
-	    let fun rl j res = 
+	    let fun rl j res =
 		    if j >= i then rl (j-1) (f(j, Array.sub(a,j), res))
 		    else res
 	    in rl start e end;
     in loop (i+n - 1) end
 
-fun appi f (slice as (a, i, n)) = 
-    let fun loop stop = 
-	    let	fun lr j = 
-		    if j < stop then (f(j, Array.sub(a,j)); lr (j+1)) 
+fun appi f (slice as (a, i, n)) =
+    let fun loop stop =
+	    let	fun lr j =
+		    if j < stop then (f(j, Array.sub(a,j)); lr (j+1))
 		    else ()
 	    in lr i end
     in loop (i+n) end
@@ -51,12 +54,12 @@ fun appi f (slice as (a, i, n)) =
 fun mapi (f : 'a -> 'b) (a, i, n) =
     let
       val newvec : 'a array = Prim.newarray(n)
-      fun copy j = 
+      fun copy j =
         if Int.<(j,n)
         then (Prim.arraystore(newvec, j, f(i+j, Array.sub(a,i+j))); copy (j+1))
         else Prim.toVector newvec
-    in 
-      copy 0 
+    in
+      copy 0
     end
 
 

--- a/src/basis/ArraySlice.sml
+++ b/src/basis/ArraySlice.sml
@@ -29,26 +29,26 @@ fun subslice ((a,i,n),j,NONE) =
 
 fun foldli f e (slice as (a, i, n)) =
     let fun loop stop =
-	    let fun lr j res =
-		if j < stop then lr (j+1) (f(j, Array.sub(a,j), res))
-		else res
-	    in lr i e end
+      let fun lr j res =
+    if j < stop then lr (j+1) (f(j, Array.sub(a,j), res))
+    else res
+      in lr i e end
     in loop (i+n) end
 
 fun foldri f e (slice as (a, i, n)) =
     let fun loop start =
-	    let fun rl j res =
-		    if j >= i then rl (j-1) (f(j, Array.sub(a,j), res))
-		    else res
-	    in rl start e end;
+      let fun rl j res =
+        if j >= i then rl (j-1) (f(j, Array.sub(a,j), res))
+        else res
+      in rl start e end;
     in loop (i+n - 1) end
 
 fun appi f (slice as (a, i, n)) =
     let fun loop stop =
-	    let	fun lr j =
-		    if j < stop then (f(j, Array.sub(a,j)); lr (j+1))
-		    else ()
-	    in lr i end
+      let	fun lr j =
+        if j < stop then (f(j, Array.sub(a,j)); lr (j+1))
+        else ()
+      in lr i end
     in loop (i+n) end
 
 fun mapi (f : 'a -> 'b) (a, i, n) =
@@ -79,15 +79,15 @@ fun all (p : 'a -> bool) ((a,i,n) : 'a slice) : bool =
 fun exists (p : 'a -> bool) ((a,i,n) : 'a slice) : bool =
   let
     val stop = i+n
-	  fun go (a,j) = j < stop andalso (p (Array.sub(a,j)) orelse go (a,j+1))
+    fun go (a,j) = j < stop andalso (p (Array.sub(a,j)) orelse go (a,j+1))
   in go (a,i)
   end
 fun find (p : 'a -> bool) ((a,i,n) : 'a slice) : 'a option =
   let
     val stop = i+n
-	  fun go j =
+    fun go j =
       if j < stop then
-  	if p (Array.sub(a,j)) then SOME (Array.sub(a,j)) else go (j+1)
+    if p (Array.sub(a,j)) then SOME (Array.sub(a,j)) else go (j+1)
       else NONE
   in go i
   end
@@ -95,9 +95,9 @@ fun findi (p : int * 'a -> bool) ((a,i,n) : 'a slice) : (int * 'a) option =
   let
     val stop = i+n
     fun go j =
-	    if j < stop then
-      if p (j-i, Array.sub(a,j)) then SOME (j-i, Array.sub(a,j)) else go (j+1)
-      else NONE
+      if j < stop then
+        if p (j-i, Array.sub(a,j)) then SOME (j-i, Array.sub(a,j)) else go (j+1)
+        else NONE
   in go i
   end
 fun collate cmp ((a1,i1,n1), (a2,i2,n2)) =
@@ -122,16 +122,16 @@ fun copyVec _ = raise Fail "ArraySlice.copyVec not implemented"
 fun modifyi f (a, i, n) =
   let
     val stop = i+n
-	  fun go (a,j) =
-	    if j < stop then (Array.update(a,j,f(j-i, Array.sub(a,j))); go (a,j+1))
-	    else ()
+    fun go (a,j) =
+      if j < stop then (Array.update(a,j,f(j-i, Array.sub(a,j))); go (a,j+1))
+      else ()
   in go (a,i)
   end
 fun modify f (a, i, n) =
   let
     val stop = i+n
-	  fun go (a,j) = if j < stop then (Array.update(a,j,f(Array.sub(a,j))); go (a,j+1))
-          	       else ()
+    fun go (a,j) = if j < stop then (Array.update(a,j,f(Array.sub(a,j))); go (a,j+1))
+                   else ()
     in go (a,i)
     end
 end

--- a/src/basis/LargeWord.sml
+++ b/src/basis/LargeWord.sml
@@ -1,8 +1,8 @@
 structure LargeWord : WORD =
 struct
 
-local 
-  open General Bool Option 
+local
+  open General Bool Option
   val op= = Prim.=
 in
 
@@ -10,25 +10,28 @@ val wordSize = 64
 
 fun toLargeWordX w = w
 fun toLargeWord w = w
+val toLarge = toLargeWord
+val toLargeX = toLargeWordX
 fun fromLargeWord w = w
+val fromLarge = fromLargeWord
 
 open PrimUtils_.LargeWord
 
-fun min (x, y) = if x < y then x else y 
+fun min (x, y) = if x < y then x else y
 fun max (x, y) = if x < y then y else x
 
 val fmt = Utils_.fmt {lt = op <,
 		     mod = op mod,
-		     div = op div, 
+		     div = op div,
 		     fromInt = fromInt,
 		     toInt = toInt,
-		     zero = 0wx0} 
-    
+		     zero = 0wx0}
+
 fun scan radix getc src = Utils_.scanWord{+ = op +, * = op *, fromInt = fromInt} radix getc src
 
 val fromString = StringCvt.scanString (scan StringCvt.HEX)
 
-val toString = fmt StringCvt.HEX 
+val toString = fmt StringCvt.HEX
 
 
 end (* of local open General Bool Option *)

--- a/src/basis/WORD.sig
+++ b/src/basis/WORD.sig
@@ -2,39 +2,42 @@ signature WORD =
 sig
 
      eqtype word
-     val wordSize : int 
+     val wordSize : int
+     val toLarge : word -> LargeWord.word
+     val toLargeX : word -> LargeWord.word
      val toLargeWord : word -> LargeWord.word
      val toLargeWordX : word -> LargeWord.word
-     val fromLargeWord : LargeWord.word -> word 
+     val fromLargeWord : LargeWord.word -> word
+     val fromLarge : LargeWord.word -> word
      val toLargeInt : word -> LargeInt.int
      val toLargeIntX : word -> LargeInt.int
-     val fromLargeInt : LargeInt.int -> word 
-     val toInt : word -> Int.int 
-     val toIntX : word -> Int.int 
-     val fromInt : Int.int -> word 
-     val orb : (word * word) -> word 
-     val xorb : (word * word) -> word 
-     val andb : (word * word) -> word 
-     val notb : word -> word 
-     val << : (word * Word.word) -> word 
-     val >> : (word * Word.word) -> word 
-     val ~>> : (word * Word.word) -> word 
-     val + : (word * word) -> word 
-     val - : (word * word) -> word 
-     val * : (word * word) -> word 
-     val div : (word * word) -> word 
-     val mod : (word * word) -> word 
-     val compare : (word * word) -> order 
-     val > : (word * word) -> bool 
-     val < : (word * word) -> bool 
-     val >= : (word * word) -> bool 
-     val <= : (word * word) -> bool 
-     val min : (word * word) -> word 
-     val max : (word * word) -> word 
-     val fmt : StringCvt.radix -> word -> string 
-     val toString : word -> string 
-     val fromString : string -> word option 
+     val fromLargeInt : LargeInt.int -> word
+     val toInt : word -> Int.int
+     val toIntX : word -> Int.int
+     val fromInt : Int.int -> word
+     val orb : (word * word) -> word
+     val xorb : (word * word) -> word
+     val andb : (word * word) -> word
+     val notb : word -> word
+     val << : (word * Word.word) -> word
+     val >> : (word * Word.word) -> word
+     val ~>> : (word * Word.word) -> word
+     val + : (word * word) -> word
+     val - : (word * word) -> word
+     val * : (word * word) -> word
+     val div : (word * word) -> word
+     val mod : (word * word) -> word
+     val compare : (word * word) -> order
+     val > : (word * word) -> bool
+     val < : (word * word) -> bool
+     val >= : (word * word) -> bool
+     val <= : (word * word) -> bool
+     val min : (word * word) -> word
+     val max : (word * word) -> word
+     val fmt : StringCvt.radix -> word -> string
+     val toString : word -> string
+     val fromString : string -> word option
      val scan : StringCvt.radix -> (char, 'a) StringCvt.reader -> 'a
-     -> (word * 'a) option 
+     -> (word * 'a) option
 
 end

--- a/src/basis/clr/PrimUtils_.sml
+++ b/src/basis/clr/PrimUtils_.sml
@@ -121,10 +121,11 @@ fun x > y  = Prim.gt(x:int,y)
 fun x <= y = Prim.=(Prim.gt(x:int,y), false)
 fun x >= y = Prim.=(Prim.lt(x:int,y), false)
 
-fun x + y = Prim.add(x:int,y)
-fun x - y = Prim.sub(x:int,y)
+(* NOTE: Integer operations should check for overflow *)
+fun x + y = Prim.add_ovf(x:int,y)
+fun x - y = Prim.sub_ovf(x:int,y)
 fun ~x    = Prim.neg(x:int)
-fun x * y = Prim.mul(x:int,y)
+fun x * y = Prim.mul_ovf(x:int,y)
 
 (* fun quot (x,y) = Prim.div(x:int,y) *)
 fun quot (x,y) = Prim.div(x:int,y)
@@ -487,9 +488,16 @@ fun fromInt i = Prim.toWord64(Prim.I42I8(i))
 
 (*@TODO: +,-,* need to avoid overflow checks and test! *)
 (*@BUG: +,-,* may raise overflow *)
-fun x + y = Prim.toWord64 (Prim.add_ovf_un(Prim.fromWord64 x, Prim.fromWord64 y))
+(* fun x + y = Prim.toWord64 (Prim.add_ovf_un(Prim.fromWord64 x, Prim.fromWord64 y))
 fun x - y = Prim.toWord64 (Prim.sub_ovf_un(Prim.fromWord64 x, Prim.fromWord64 y))
-fun x * y = Prim.toWord64 (Prim.mul_ovf_un(Prim.fromWord64 x, Prim.fromWord64 y))
+fun x * y = Prim.toWord64 (Prim.mul_ovf_un(Prim.fromWord64 x, Prim.fromWord64 y)) *)
+(* TODO: Check if this is correct or not. This looks similar to what C# does
+   in that it uses the add, sub, and mul for unchecked operations between ulongs,
+   but all the conversions between ints and words look suspicious.
+ *)
+fun x + y = Prim.toWord64 (Prim.add(Prim.fromWord64 x, Prim.fromWord64 y))
+fun x - y = Prim.toWord64 (Prim.sub(Prim.fromWord64 x, Prim.fromWord64 y))
+fun x * y = Prim.toWord64 (Prim.mul(Prim.fromWord64 x, Prim.fromWord64 y))
 
 fun orb (x, y) = Prim.toWord64(Prim.or(Prim.fromWord64 x, Prim.fromWord64 y))
 fun xorb (x, y) = Prim.toWord64(Prim.xor(Prim.fromWord64 x, Prim.fromWord64 y))

--- a/src/basis/clr/PrimUtils_.sml
+++ b/src/basis/clr/PrimUtils_.sml
@@ -5,8 +5,8 @@ structure PrimUtils_ =
 struct
 
 val op= = Prim.=
-fun x <> y = 
-  case Prim.=(x,y) of 
+fun x <> y =
+  case Prim.=(x,y) of
     true => false
   | false => true
 
@@ -14,24 +14,24 @@ fun x <> y =
 (* Radix conversion							*)
 (*----------------------------------------------------------------------*)
 (* fun isDigit(c : char, i : int) = System.Radix.IsDigit(c,i) *)
-fun isDigit(c:char,i:int) = 
-    if Prim.lt(i,11) then 
+fun isDigit(c:char,i:int) =
+    if Prim.lt(i,11) then
 	(* 0<=c andalso c < i < 11*)
-	Prim.=((Prim.gt(#"0",c)),false) andalso 
+	Prim.=((Prim.gt(#"0",c)),false) andalso
 	Prim.lt(c,Prim.toChar(Prim.add(Prim.fromChar(#"0"),i)))
-    else (Prim.=((Prim.gt(#"0",c)),false) andalso 
-          Prim.=((Prim.lt(#"9",c)),false)) 
-         orelse 
-	 (Prim.=((Prim.gt(#"a",c)),false) andalso 
+    else (Prim.=((Prim.gt(#"0",c)),false) andalso
+          Prim.=((Prim.lt(#"9",c)),false))
+         orelse
+	 (Prim.=((Prim.gt(#"a",c)),false) andalso
 	  Prim.lt(c,Prim.toChar(Prim.add(Prim.fromChar(#"a"),Prim.sub(i,10)))))
 	 orelse
-	 (Prim.=((Prim.gt(#"A",c)),false) andalso 
+	 (Prim.=((Prim.gt(#"A",c)),false) andalso
 	  Prim.lt(c,Prim.toChar(Prim.add(Prim.fromChar(#"A"),Prim.sub(i,10)))))
-    
+
 
 fun string (s:string, i:int, n:int) = Prim.unsafeValOf(s.#Substring(i, n))
 
-fun strCompare(s1 : string,s2 : string) = 
+fun strCompare(s1 : string,s2 : string) =
   _pure(System.String.CompareOrdinal(s1,s2))
 
 (* fun nowInMillis () = Prim.i2l System.Environment.get_TickCount ()) *)
@@ -43,7 +43,7 @@ val epoch = _pure(System.DateTime( (*year*)   1970,
 	                     (*hour*)   00,
 	                     (*minute*) 00,
 	                     (*second*) 00))
-fun nowInMillis () = 
+fun nowInMillis () =
     Prim.div(((System.DateTime.get_UtcNow()
 	      .#Subtract(epoch))
 	      :System.TimeSpan)
@@ -192,7 +192,7 @@ fun isNan x = System.Double.IsNaN(x)
 fun fromInt x = Prim.I42R4 (x:int)
 
 (*@TODO: review *)
-fun toString x = Prim.unsafeValOf(System.Convert.ToString(x:real)) 
+fun toString x = Prim.unsafeValOf(System.Convert.ToString(x:real))
 
 fun trunc x = Prim.R42I4_ovf x
 
@@ -203,9 +203,9 @@ val maxFinite = System.Single.MaxValue
 
 fun realFloor x = Prim.R82R4 (System.Math.Floor(Prim.R42R8 x))
 
-fun realCeil x = Prim.R82R4 (System.Math.Ceiling(Prim.R42R8 x)) 
+fun realCeil x = Prim.R82R4 (System.Math.Ceiling(Prim.R42R8 x))
 
-fun round x = System.Convert.ToInt32(x:real)  
+fun round x = System.Convert.ToInt32(x:real)
 
 fun fromLarge mode r = Prim.R82R4 r
 val toLarge = Prim.R42R8
@@ -224,14 +224,17 @@ type word = Prim.U1
 
 fun toLargeWord w =  Prim.I42U8(Prim.fromWord8(w))
 fun toLargeWordX w = Prim.toWord64(Prim.I42I8(Prim.fromWord8(w)))
+val toLarge = toLargeWord
+val toLargeX = toLargeWordX
 fun fromLargeWord w  = Prim.I82U1_ovf_un(Prim.And(Prim.fromWord64(0wxFF),Prim.fromWord64(w)))
+val fromLarge = fromLargeWord
 
 fun toLargeInt w = Prim.fromWord64(Prim.I42U8 (Prim.fromWord8 w))
 fun toLargeIntX w = Prim.I42I8(Prim.fromWord8 w)
 fun fromLargeInt i = Prim.I82U1(i)
 
-fun toIntX w = 
-    let val i = Prim.fromWord8(w) 
+fun toIntX w =
+    let val i = Prim.fromWord8(w)
     in if Prim.=(Prim.And(i,128),0)
 	   then i
        else (Prim.or(i,~256))
@@ -262,27 +265,27 @@ fun compare(x,y) =
     if x = y then EQUAL
     else
     let val x = Prim.fromWord8 x
-	val y = Prim.fromWord8 y 
-    in if Prim.lt_un(x,y) then LESS 
+	val y = Prim.fromWord8 y
+    in if Prim.lt_un(x,y) then LESS
        else GREATER
     end
 
 fun x div y = Prim.toWord8(Prim.div_un(Prim.fromWord8 x,Prim.fromWord8 y))
 fun x mod y = Prim.toWord8(Prim.rem_un(Prim.fromWord8 x,Prim.fromWord8 y))
 
-fun << (i, n) = 
+fun << (i, n) =
   if Prim.And(Prim.fromWord n, Prim.fromWord 0wxfffffff8) <> 0 (* n>7 *)
   then 0w0
   else Prim.I42U1(Prim.shl(Prim.fromWord8 i,n))
 
-fun >> (i, n) = 
+fun >> (i, n) =
   if Prim.And(Prim.fromWord n, Prim.fromWord 0wxfffffff8) <> 0 (* n>7 *)
   then 0w0
   else Prim.toWord8(Prim.ushr(Prim.fromWord8 i, n))
 
-fun ~>> (i, n) = 
+fun ~>> (i, n) =
   (*@TODO: optimize *)
-  (* pad bits to left of i[0-7] with (at least) 7  0s or 1s depending on bit i[7], 
+  (* pad bits to left of i[0-7] with (at least) 7  0s or 1s depending on bit i[7],
      32-bit logical shift right by max(n,7),
      normalize *)
   Prim.I42U1(Prim.And(Prim.ushr(if Prim.And(Prim.fromWord8 i,Prim.fromWord 0w128) <> 0 (* negative *)
@@ -290,7 +293,7 @@ fun ~>> (i, n) =
 				else Prim.fromWord8 i, (* bits 31,-,8 = 0 *)
 				(* shift by max(n,7) *)
 				if Prim.And(Prim.fromWord n, Prim.fromWord 0wxfffffff8) <> 0
-				    then 0w7 
+				    then 0w7
 				else n),
 		      (* normalize *)
 		      Prim.fromWord (0wxff)))
@@ -301,21 +304,24 @@ end
 (*----------------------------------------------------------------------*)
 (* 16-bit unsigned integers						*)
 (*----------------------------------------------------------------------*)
-structure Word16 = 
+structure Word16 =
 struct
 
 type word = Prim.U2
 
 fun toLargeWord w =  Prim.I42U8(Prim.fromWord16(w))
 fun toLargeWordX w = Prim.toWord64(Prim.I42I8(Prim.fromWord16(w)))
+val toLarge = toLargeWord
+val toLargeX = toLargeWordX
 fun fromLargeWord w  = Prim.I82U1_ovf_un(Prim.And(Prim.fromWord64(0wxFFFF),Prim.fromWord64(w)))
+val fromLarge = fromLargeWord
 
 fun toLargeInt w = Prim.fromWord64(Prim.I42U8 (Prim.fromWord16 w))
 fun toLargeIntX w = Prim.I42I8(Prim.fromWord16 w)
 fun fromLargeInt i = Prim.I82U2(i)
 
-fun toIntX w = 
-    let val i = Prim.fromWord16(w) 
+fun toIntX w =
+    let val i = Prim.fromWord16(w)
     in if Prim.=(Prim.And(i,32768),0)
 	   then i
        else (Prim.or(i,~65536))
@@ -323,7 +329,7 @@ fun toIntX w =
 
 
 fun toInt w = Prim.And(Prim.fromWord16(w),65535)
-fun fromInt i = Prim.toWord16(Prim.And(i,65535)) 
+fun fromInt i = Prim.toWord16(Prim.And(i,65535))
 
 
 fun x < y  = Prim.lt_un(Prim.fromWord16 x,Prim.fromWord16 y)
@@ -343,27 +349,27 @@ fun compare(x,y) =
     if x = y then EQUAL
     else
     let val x = Prim.fromWord16 x
-	val y = Prim.fromWord16 y 
-    in if Prim.lt_un(x,y) then LESS 
+	val y = Prim.fromWord16 y
+    in if Prim.lt_un(x,y) then LESS
        else GREATER
     end
 
 fun x div y = Prim.toWord16(Prim.div_un(Prim.fromWord16 x,Prim.fromWord16 y))
 fun x mod y = Prim.toWord16(Prim.rem_un(Prim.fromWord16 x,Prim.fromWord16 y))
 
-fun << (i, n) = 
+fun << (i, n) =
   if Prim.And(Prim.fromWord n, Prim.fromWord 0wxfffffff0) <> 0 (* n>15 *)
   then 0w0
   else Prim.I42U2(Prim.shl(Prim.fromWord16 i,n))
 
-fun >> (i, n) = 
+fun >> (i, n) =
   if Prim.And(Prim.fromWord n, Prim.fromWord 0wxfffffff0) <> 0 (* n>15 *)
   then 0w0
   else Prim.toWord16(Prim.ushr(Prim.fromWord16 i, n))
 
-fun ~>> (i, n) = 
+fun ~>> (i, n) =
   (*@TODO: optimize *)
-  (* pad bits to left of i[0-15] with (at least) 15  0s or 1s depending on bit i[15], 
+  (* pad bits to left of i[0-15] with (at least) 15  0s or 1s depending on bit i[15],
      32-bit logical shift right by max(n,15),
      normalize *)
   Prim.I42U2(Prim.And(Prim.ushr(if Prim.And(Prim.fromWord16 i,Prim.fromWord 0w32768) <> 0 (* negative *)
@@ -371,7 +377,7 @@ fun ~>> (i, n) =
 				else Prim.fromWord16 i, (* bits 31,-,16 = 0 *)
 				(* shift by max(n,15) *)
 				if Prim.And(Prim.fromWord n, Prim.fromWord 0wxfffffff0) <> 0
-				    then 0w15 
+				    then 0w15
 				else n),
 		      (* normalize *)
 		      Prim.fromWord (0wxffff)))
@@ -390,7 +396,10 @@ type word = Prim.U4
 
 fun toLargeWord w =  Prim.I42U8(Prim.fromWord(w))
 fun toLargeWordX w = Prim.toWord64(Prim.I42I8(Prim.fromWord(w)))
+val toLarge = toLargeWord
+val toLargeX = toLargeWordX
 fun fromLargeWord w  = Prim.I82U4_ovf_un(Prim.And(Prim.fromWord64(0wxFFFFFFFF),Prim.fromWord64(w)))
+val fromLarge = fromLargeWord
 
 fun toLargeInt w = Prim.fromWord64(Prim.I42U8 (Prim.fromWord w))
 fun toLargeIntX w = Prim.I42I8(Prim.fromWord w)
@@ -410,16 +419,16 @@ fun x + y = Prim.toWord (Prim.add(Prim.fromWord x, Prim.fromWord y))
 fun x - y = Prim.toWord (Prim.sub(Prim.fromWord x, Prim.fromWord y))
 fun x * y = Prim.toWord (Prim.mul(Prim.fromWord x, Prim.fromWord y))
 *)
-fun x + y = 
+fun x + y =
     Prim.I82U4(Prim.And(0xFFFFFFFF,
 			Prim.add(Prim.I42I8_ovf_un(Prim.fromWord x),
 				 Prim.I42I8_ovf_un(Prim.fromWord y))))
-fun x - y = 
+fun x - y =
     Prim.I82U4(Prim.And(0xFFFFFFFF,
 			Prim.sub(Prim.add(0x100000000,
 					  Prim.I42I8_ovf_un(Prim.fromWord x)),
 				 Prim.I42I8_ovf_un(Prim.fromWord y))))
-fun x * y = 
+fun x * y =
     Prim.I82U4(Prim.And(0xFFFFFFFF,
 			Prim.mul_ovf_un(Prim.I42I8_ovf_un(Prim.fromWord x),
 					Prim.I42I8_ovf_un(Prim.fromWord y))))
@@ -433,26 +442,26 @@ fun compare(x,y) =
     if x = y then EQUAL
     else
     let val x = Prim.fromWord x
-	val y = Prim.fromWord y 
-    in if Prim.lt_un(x,y) then LESS 
+	val y = Prim.fromWord y
+    in if Prim.lt_un(x,y) then LESS
        else GREATER
     end
 
 fun x div y = Prim.toWord(Prim.div_un(Prim.fromWord x,Prim.fromWord y))
 fun x mod y = Prim.toWord(Prim.rem_un(Prim.fromWord x,Prim.fromWord y))
 
-fun << (i, n) = 
+fun << (i, n) =
   if Prim.And(Prim.fromWord n, Prim.fromWord 0wxffffffe0) <> 0
   then 0w0
   else Prim.toWord(Prim.shl(Prim.fromWord i, n))
 
-fun >> (i, n) = 
+fun >> (i, n) =
   if Prim.And(Prim.fromWord n, Prim.fromWord 0wxffffffe0) <> 0
   then 0w0
   else Prim.toWord(Prim.ushr(Prim.fromWord i, n))
 
-fun ~>> (i, n) = 
-  Prim.toWord(Prim.shr(Prim.fromWord i, 
+fun ~>> (i, n) =
+  Prim.toWord(Prim.shr(Prim.fromWord i,
       if Prim.And(Prim.fromWord n, Prim.fromWord 0wxffffffe0) <> 0
       then 0wx1f else n))
 
@@ -491,8 +500,8 @@ fun compare(x,y) =
     if x = y then EQUAL
     else
     let val x = Prim.fromWord64 x
-	val y = Prim.fromWord64 y 
-    in if Prim.lt_un(x,y) then LESS 
+	val y = Prim.fromWord64 y
+    in if Prim.lt_un(x,y) then LESS
        else GREATER
     end
 
@@ -504,18 +513,18 @@ fun x >= y = Prim.=(Prim.lt_un(Prim.fromWord64 x, Prim.fromWord64 y),false)
 fun x div y = Prim.toWord64(Prim.div_un(Prim.fromWord64 x,Prim.fromWord64 y))
 fun x mod y = Prim.toWord64(Prim.rem_un(Prim.fromWord64 x,Prim.fromWord64 y))
 
-fun << (i, n) = 
+fun << (i, n) =
   if Prim.And(Prim.fromWord n, Prim.fromWord 0wxffffffc0) <> 0  (* n>64 *)
   then 0w0
   else Prim.toWord64(Prim.shl(Prim.fromWord64 i, n))
 
-fun >> (i, n) = 
+fun >> (i, n) =
   if Prim.And(Prim.fromWord n, Prim.fromWord 0wxffffffc0) <> 0 (* n>64 *)
   then 0w0
   else Prim.toWord64(Prim.ushr(Prim.fromWord64 i, n))
 
-fun ~>> (i, n) = 
-  Prim.toWord64(Prim.shr(Prim.fromWord64 i, 
+fun ~>> (i, n) =
+  Prim.toWord64(Prim.shr(Prim.fromWord64 i,
     if Prim.And(Prim.fromWord n, Prim.fromWord 0wxffffffc0) <> 0
     then 0wx3f else n))
 
@@ -539,7 +548,7 @@ fun ord c =Prim.fromChar c
 (* verbatim from Basis spec *)
 fun isUpper c = #"A" <= c andalso c <= #"Z"
 fun isLower c = #"a" <= c andalso c <= #"z"
-fun isDigit c = #"0" <= c andalso c <= #"9" 
+fun isDigit c = #"0" <= c andalso c <= #"9"
 fun isAlpha c = isUpper c orelse isLower c
 fun isAlphaNum c = isAlpha c orelse isDigit c
 fun isHexDigit c = isDigit c orelse (#"a" <= c andalso c <= #"f")
@@ -557,19 +566,19 @@ val maxOrd = 65535
 
 exception Chr
 
-fun chr i = 
-  if Int.<(i, 0) orelse Int.>(i, maxOrd) 
+fun chr i =
+  if Int.<(i, 0) orelse Int.>(i, maxOrd)
   then raise Chr
   else Prim.toChar i
 
-fun contains (s : string) (c : char) = 
+fun contains (s : string) (c : char) =
   case _pure (s.#IndexOf (c)) of
-    ~1 => false 
+    ~1 => false
   | _ => true
 
-fun notContains (s : string) (c : char) = 
+fun notContains (s : string) (c : char) =
   case _pure (s.#IndexOf (c)) of
-    ~1 => true 
+    ~1 => true
   | _ => false
 
 end
@@ -589,10 +598,10 @@ fun size (s : string) = _pure (s.#get_Length ())
    Subscript if i<0 or size s <= i *)
 fun sub(s:string, i) = s.#get_Chars(i)
 
-fun (s1 : string) ^ (s2 : string) = 
-  Prim.unsafeValOf(_pure (System.String.Concat(s1,s2))) 
+fun (s1 : string) ^ (s2 : string) =
+  Prim.unsafeValOf(_pure (System.String.Concat(s1,s2)))
 
-fun str (c : char) = 
+fun str (c : char) =
   Prim.unsafeValOf(_pure (System.Char.ToString(c)))
 
 fun extract(s : string, i:int, nopt:int option) =
@@ -602,8 +611,8 @@ fun extract(s : string, i:int, nopt:int option) =
   | SOME n => s.#Substring(i, n)
   )
 
-fun compare(s1 : string,s2 : string) = 
-  let 
+fun compare(s1 : string,s2 : string) =
+  let
     val i = _pure(System.String.CompareOrdinal(s1,s2))
   in
     if Int.<(i,0) then Datatypes.LESS else
@@ -624,7 +633,7 @@ in
   (* Will get stamp 2 because of earlier exception Chr *)
   _classtype [abstract] MLExn(s:string option) : System.Exception(s)
   with
-      ToString() = 
+      ToString() =
         let
           val prefix = this.#ExnMessage ()
         in
@@ -632,7 +641,7 @@ in
             NONE => SOME prefix
           | SOME m => SOME (prefix ^ m)
         end
-  and ExnMessage () = 
+  and ExnMessage () =
           this.#ExnName () ^ ": " ^ unsafeValOf(this.#get_Message())
   and ExnName () = "SML exception"
   end
@@ -644,10 +653,10 @@ struct
      exception Size = System.ArgumentException
      (*@TODO: previously, exception Overflow = System.ArithmeticException *)
      exception Overflow = System.OverflowException
-     (*@NOTE: previously, a subclass of Overflow = System.ArithmeticException --- did we rely on this?*) 
-     exception Div = System.DivideByZeroException 
+     (*@NOTE: previously, a subclass of Overflow = System.ArithmeticException --- did we rely on this?*)
+     exception Div = System.DivideByZeroException
 
-     fun exnName (e : exn) = 
+     fun exnName (e : exn) =
        case e of
          Subscript => "General.Subscript"
        | Size => "General.Size"
@@ -669,7 +678,7 @@ struct
        | Div => "General.Div"
        | Overflow => "General.Overflow"
        | _ =>
-         case e of 
+         case e of
 (*@todo akenn: restore this
          mle :> MLExn => mle.#ExnMessage ()
        | *) _ => Prim.unsafeValOf(e.#ToString())

--- a/src/common/values/MulCarryLong.sml
+++ b/src/common/values/MulCarryLong.sml
@@ -22,5 +22,6 @@ struct
       (carry,mul)
    end
 
-   fun mul16 w=(Word64.>>(w,0w28),Word64.<<(w,0w4))
+   (* NOTE: 0w28 was carry for 32 bit words, so 0x60 is carry for 64 bit words? *)
+   fun mul16 w=(Word64.>>(w,0w60),Word64.<<(w,0w4))
 end

--- a/src/common/values/RTInt.sml
+++ b/src/common/values/RTInt.sml
@@ -98,11 +98,11 @@ struct
       fun W2w x=Word.fromLargeWord(Word32.toLargeWord x)
 
       fun deword f (x,y)= w2i(f(i2w x,i2w y))
-      val add=Int32.+
+      val add=deword Word32.+
       val sub=Int32.-
       fun neg x=Int32.-(0,x)
 
-      val mul=Int32.*
+      val mul=deword Word32.*
       fun x div y=
       if y=0 then NONE
       else

--- a/src/common/values/RTInt.sml
+++ b/src/common/values/RTInt.sml
@@ -75,7 +75,7 @@ struct
    val fromString=IC.fromString
    val toString=Int32.toString
 
-   structure numops:>NUMOPS where type num=Int32.int 
+   structure numops:>NUMOPS where type num=Int32.int
       where type shiftnum=Int32.int=
    struct
       type num=Int32.int
@@ -98,16 +98,16 @@ struct
       fun W2w x=Word.fromLargeWord(Word32.toLargeWord x)
 
       fun deword f (x,y)= w2i(f(i2w x,i2w y))
-      val add=deword Word32.+
-      val sub=deword Word32.-
-      fun neg x=w2i(Word32.-(0w0,i2w x))
+      val add=Int32.+
+      val sub=Int32.-
+      fun neg x=Int32.-(0,x)
 
-      val mul=deword Word32.*
+      val mul=Int32.*
       fun x div y=
       if y=0 then NONE
       else
-         (SOME(Int32.quot(x,y))) 
-         handle 
+         (SOME(Int32.quot(x,y)))
+         handle
             Div => NONE (* division by 0 *)
          |  Overflow => SOME x
             (* Overflow can only occur when
@@ -116,7 +116,7 @@ struct
                around to get ~2^32 again *)
       fun rem(x,y)=
          (SOME(Int32.rem(x,y)))
-         handle 
+         handle
             Div => NONE (* division by 0 *)
 
       val andb=deword Word32.andb
@@ -125,15 +125,15 @@ struct
 
       fun get5bits x= W2w(Word32.andb(i2w x,0wx1f))
       fun deword5 f (x,y)=w2i(f(i2w x,get5bits y))
-      val shl=deword5 Word32.<< 
+      val shl=deword5 Word32.<<
       val shr=deword5 Word32.~>>
       val ushr=deword5 Word32.>>
-    
+
       val compare=Int32.compare
       val Compare=SOME o compare
-      fun lt(a,b)=(compare(a,b)=LESS)      
+      fun lt(a,b)=(compare(a,b)=LESS)
       fun le(a,b)=(compare(a,b)<>GREATER)
-   end  
+   end
 
    exception RTInt_Overflow=numops.NumOverflow
 

--- a/src/common/values/RTLong.sml
+++ b/src/common/values/RTLong.sml
@@ -58,11 +58,11 @@ struct
       fun W2w x=Word.fromLargeWord(Word64.toLargeWord x)
 
       fun deword f (x,y)= w2i(f(i2w x,i2w y))
-      val add=Int64.+
+      val add=deword Word64.+
       val sub=Int64.-
       fun neg x=Int64.-(0,x)
 
-      val mul=Int64.*
+      val mul=deword Word64.*
       fun x div y=
       if y=0 then NONE
       else

--- a/src/common/values/RTLong.sml
+++ b/src/common/values/RTLong.sml
@@ -58,11 +58,11 @@ struct
       fun W2w x=Word.fromLargeWord(Word64.toLargeWord x)
 
       fun deword f (x,y)= w2i(f(i2w x,i2w y))
-      val add=deword Word64.+
-      val sub=deword Word64.-
-      fun neg x=w2i(Word64.-(0w0,i2w x))
+      val add=Int64.+
+      val sub=Int64.-
+      fun neg x=Int64.-(0,x)
 
-      val mul=deword Word64.*
+      val mul=Int64.*
       fun x div y=
       if y=0 then NONE
       else


### PR DESCRIPTION
Modifications to the library functions and runtime so that `smlfmt` and `smlgen` compile and appear to run successfully.

* Adds `insertWith` and `insertWithi` for hashtables
* Adds `ArraySlice` functions
* Adds `toLarge`, `toLargeX`, and `fromLarge` to `WORD`
* Modifies `Prim` so that `Int`s check for overflow and `Word64`s do not check for overflow
* Fix `MulCarryLong`'s carry for multiplying by 16 so large hexadecimal Word64 literals are accepted
* Modify `RTInt` and `RTLong`s subtraction and negative ops to use the integer ops instead of words to prevent large positive numbers