### PR TITLE
Remove assignments to refs in Deunit and start tests

### DIFF
--- a/src/common/values/RTInt.sml
+++ b/src/common/values/RTInt.sml
@@ -99,8 +99,8 @@ struct
 
       fun deword f (x,y)= w2i(f(i2w x,i2w y))
       val add=deword Word32.+
-      val sub=Int32.-
-      fun neg x=Int32.-(0,x)
+      val sub=deword Word32.-
+      fun neg x=w2i(Word32.-(0w0,i2w x))
 
       val mul=deword Word32.*
       fun x div y=

--- a/src/common/values/RTLong.sml
+++ b/src/common/values/RTLong.sml
@@ -59,8 +59,8 @@ struct
 
       fun deword f (x,y)= w2i(f(i2w x,i2w y))
       val add=deword Word64.+
-      val sub=Int64.-
-      fun neg x=Int64.-(0,x)
+      val sub=deword Word64.-
+      fun neg x=w2i(Word64.-(0w0,i2w x))
 
       val mul=deword Word64.*
       fun x div y=

--- a/test/Regression1.il.expected
+++ b/test/Regression1.il.expected
@@ -1,0 +1,330 @@
+.assembly extern mscorlib {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 4:0:0:0
+}
+.assembly extern Accessibility {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Configuration.Install {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Data {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.DirectoryServices {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.Drawing {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.EnterpriseServices {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Management {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Messaging {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Runtime.Remoting {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.Runtime.Serialization.Formatters.Soap {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Security {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.ServiceProcess {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern Mono.Unix {
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )
+  .ver 7:1:0:0
+}
+.assembly 'Regression1'
+{ .hash algorithm 0x00008004 }
+.module 'Regression1.exe'
+
+.namespace '$' {
+.class  private abstract 'Class_a' extends ['mscorlib']'System'.'Exception'{
+
+.field private initonly string 's'
+.method public instance void '.ctor'(string 's') cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  ldarg.1
+  call instance instance void ['mscorlib']'System'.'Exception'::'.ctor'(string)
+  ldarg.0
+  ldarg.1
+  stfld string '$'.'Class_a'::'s'
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ToString'() cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  callvirt instance string '$'.'Class_a'::'ExnMessage'()
+  stloc.0
+  ldsfld string '$'.'Globals'::'$l'
+  stloc.1
+  ldloc.1
+  ldnull
+  ceq
+  stloc.2
+  ldloc.2
+  brtrue L_1
+  ldloc.0
+  ldloc.1
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldloc.0
+  ret
+L_1:
+  ldloc.0
+  ret
+{.locals ([0] string /*cryt 'PrimUtils_.prefix'*/ ,
+         [1] string /*cryr*/ ,
+         [2] bool /*csaa*/ )}
+}
+.method public virtual instance string 'ExnMessage'() cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  callvirt instance string '$'.'Class_a'::'ExnName'()
+  stloc.0
+  ldloc.0
+  ldstr ": "
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldarg.0
+  callvirt instance string ['mscorlib']'System'.'Exception'::'get_Message'()
+  stloc.1
+  ldloc.0
+  ldloc.1
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldloc.0
+  ret
+{.locals ([0] string /*cryz cryx cryw*/ ,
+         [1] string /*cryy*/ )}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 1
+.zeroinit
+  ldstr "SML exception"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.class  public sealed 'Regression1' extends ['mscorlib']'System'.'Object'{
+
+.method public static void '.cctor'() cil {
+.maxstack 0
+.zeroinit
+  call void '$'.'Globals'::'$'()
+  ret
+{.locals ()}
+}
+.method public static void 'main'() cil {
+.maxstack 0
+.zeroinit
+.entrypoint
+  ret
+{.locals ()}
+}
+
+}
+
+.namespace '$' {
+.class  private 'Fun' extends ['mscorlib']'System'.'Object'{
+
+.method assembly instance void '.ctor'() cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'General' {
+.class  private sealed 'Fail' extends '$'.'Class_a'{
+
+.method assembly instance void '.ctor'(string '') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldarg.1
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "General.Fail"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private 'Globals' extends ['mscorlib']'System'.'Object'{
+
+.field static assembly string '$l'
+.field static assembly int32 '$g'
+.method static assembly void '.cctor'() cil {
+.maxstack 3
+.zeroinit
+  ldc.i4.s 11
+  conv.u4
+  stloc.0
+  ldc.i4.1
+  ldloc.0
+  shl
+  stloc.1
+  ldloc.1
+  ldc.i4.1
+  sub.ovf
+  pop
+  ldc.i4.s 11
+  ldc.i4.1
+  sub.ovf
+  stloc.1
+  ldloc.1
+  conv.u4
+  stloc.0
+  ldc.i4.1
+  ldloc.0
+  shl
+  stloc.1
+  ldloc.1
+  ldc.i4.1
+  sub.ovf
+  stloc.1
+  ldloc.1
+  ldc.i4.s 52
+  add.ovf
+  stloc.2
+  ldloc.2
+  ldc.i4.1
+  sub.ovf
+  pop
+  ldc.i8 0x0000000000000040
+  conv.ovf.i4
+  stloc.2
+  ldloc.2
+  ldc.i4.1
+  sub.ovf
+  stloc.2
+  ldloc.2
+  ldloc.1
+  add.ovf
+  pop
+  call string ['mscorlib']'System'.'Environment'::'get_NewLine'()
+  stloc.3
+  ldloc.3
+  ldnull
+  ceq
+  stloc.s 4
+  ldloc.s 4
+  brtrue L_5
+  ldloc.3
+  ldc.i4.s -2147483648
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 5
+  ldloc.3
+  callvirt instance int32 ['mscorlib']'System'.'String'::'get_Length'()
+  stloc.1
+  ldloc.1
+  dup
+  ldc.i4.1
+  bne.un L_3
+  pop
+  ldloc.s 5
+  ldc.i4 10
+  ceq
+  stloc.s 4
+  ldloc.s 4
+  brtrue L_2
+  br _crzq
+L_2:
+  br _crzq
+L_3:
+  ldc.i4.2
+  bne.un L_4
+  ldloc.3
+  ldc.i4.1
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 6
+  br _crzq
+L_4:
+  ldstr " at TextIO:125.26-79"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "Unexpected line separator length"
+  newobj instance void '!'.'General'.'Fail'::.ctor(string)
+  throw
+_crzq:
+  call class ['mscorlib']'System'.'IO'.'TextReader' ['mscorlib']'System'.'Console'::'get_In'()
+  pop
+  call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Out'()
+  pop
+  call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Error'()
+  pop
+  ret
+L_5:
+  ldstr " at TextIO:118.20-68"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "No line separator available"
+  newobj instance void '!'.'General'.'Fail'::.ctor(string)
+  throw
+{.locals ([0] unsigned int32 /*crzf crzc*/ ,
+         [1] int32 /*crzp 'Real.eoffset' crzg crze crzd*/ ,
+         [2] int32 /*crzk 'Real.large_precision' 'Real.meoffset'*/ ,
+         [3] string /*crzl*/ ,
+         [4] bool /*crzw crzz*/ ,
+         [5] char /*'TextIO.c'*/ ,
+         [6] char /*crzx*/ )}
+}
+.method static assembly void '$'() cil {
+.maxstack 0
+.zeroinit
+  ret
+{.locals ()}
+}
+.method static assembly void '.GCSafePoint'() managed noinlining {
+.maxstack 0
+.zeroinit
+  ret
+{.locals ()}
+}
+
+}
+}

--- a/test/Regression1.sml
+++ b/test/Regression1.sml
@@ -1,0 +1,9 @@
+structure Regression1 = struct
+  fun main () =
+    let
+      val f = ref ()
+      val () = f := ()
+    in
+      ()
+    end
+end

--- a/test/Regression2.il.expected
+++ b/test/Regression2.il.expected
@@ -1,0 +1,585 @@
+.assembly extern mscorlib {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 4:0:0:0
+}
+.assembly extern Accessibility {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Configuration.Install {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Data {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.DirectoryServices {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.Drawing {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.EnterpriseServices {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Management {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Messaging {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Runtime.Remoting {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.Runtime.Serialization.Formatters.Soap {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Security {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.ServiceProcess {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern Mono.Unix {
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )
+  .ver 7:1:0:0
+}
+.assembly 'Regression2'
+{ .hash algorithm 0x00008004 }
+.module 'Regression2.exe'
+
+.namespace '$' {
+.class  private abstract 'Class_a' extends ['mscorlib']'System'.'Exception'{
+
+.field private initonly string 's'
+.method public instance void '.ctor'(string 's') cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  ldarg.1
+  call instance instance void ['mscorlib']'System'.'Exception'::'.ctor'(string)
+  ldarg.0
+  ldarg.1
+  stfld string '$'.'Class_a'::'s'
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ToString'() cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  callvirt instance string '$'.'Class_a'::'ExnMessage'()
+  stloc.0
+  ldsfld string '$'.'Globals'::'$l'
+  stloc.1
+  ldloc.1
+  ldnull
+  ceq
+  stloc.2
+  ldloc.2
+  brtrue L_1
+  ldloc.0
+  ldloc.1
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldloc.0
+  ret
+L_1:
+  ldloc.0
+  ret
+{.locals ([0] string /*csum 'PrimUtils_.prefix'*/ ,
+         [1] string /*csuk*/ ,
+         [2] bool /*cswy*/ )}
+}
+.method public virtual instance string 'ExnMessage'() cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  callvirt instance string '$'.'Class_a'::'ExnName'()
+  stloc.0
+  ldloc.0
+  ldstr ": "
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldarg.0
+  callvirt instance string ['mscorlib']'System'.'Exception'::'get_Message'()
+  stloc.1
+  ldloc.0
+  ldloc.1
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldloc.0
+  ret
+{.locals ([0] string /*csus csuq csup*/ ,
+         [1] string /*csur*/ )}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 1
+.zeroinit
+  ldstr "SML exception"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.class  public sealed 'Regression2' extends ['mscorlib']'System'.'Object'{
+
+.method public static void '.cctor'() cil {
+.maxstack 0
+.zeroinit
+  call void '$'.'Globals'::'$'()
+  ret
+{.locals ()}
+}
+.method public static void 'main'() cil {
+.maxstack 1
+.zeroinit
+.entrypoint
+  ldstr bytearray (68 00 65 00 6C 00 6C 00 6F 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldstr bytearray (77 00 6F 00 72 00 6C 00 64 00 0A 00 )
+  tail.
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ret
+{.locals ()}
+}
+
+}
+
+.namespace '$' {
+.class  private 'Fun' extends ['mscorlib']'System'.'Object'{
+
+.method assembly instance void '.ctor'() cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private sealed 'Tuple3_a' extends ['mscorlib']'System'.'Object'{
+
+.field assembly string '_1'
+.field assembly class ['mscorlib']'System'.'Exception' '_2'
+.field assembly string '_3'
+.method assembly instance void '.ctor'(string '_1',class ['mscorlib']'System'.'Exception' '_2',string '_3') cil {
+.maxstack 4
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ldarg.0
+  ldarg.1
+  stfld string '$'.'Tuple3_a'::'_1'
+  ldarg.0
+  ldarg.2
+  stfld class ['mscorlib']'System'.'Exception' '$'.'Tuple3_a'::'_2'
+  ldarg.0
+  ldarg.3
+  stfld string '$'.'Tuple3_a'::'_3'
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'IO' {
+.class  private sealed 'Io' extends '$'.'Class_a'{
+
+.field assembly class '$'.'Tuple3_a' '_1'
+.method assembly instance void '.ctor'(class '$'.'Tuple3_a' '') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldnull
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ldarg.0
+  ldarg.1
+  stfld class '$'.'Tuple3_a' '!'.'IO'.'Io'::'_1'
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "IO.Io"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'General' {
+.class  private sealed 'Fail' extends '$'.'Class_a'{
+
+.method assembly instance void '.ctor'(string '') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldarg.1
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "General.Fail"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private 'Globals' extends ['mscorlib']'System'.'Object'{
+
+.field static assembly string '$l'
+.field static assembly int32 '$g'
+.field static assembly string '$csve'
+.field static assembly int32 '$csvk'
+.field static assembly class ['mscorlib']'System'.'IO'.'TextWriter' '$csvn'
+.method static assembly void '.cctor'() cil {
+.maxstack 3
+.zeroinit
+  ldc.i4.s 11
+  conv.u4
+  stloc.0
+  ldc.i4.1
+  ldloc.0
+  shl
+  stloc.1
+  ldloc.1
+  ldc.i4.1
+  sub.ovf
+  pop
+  ldc.i4.s 11
+  ldc.i4.1
+  sub.ovf
+  stloc.1
+  ldloc.1
+  conv.u4
+  stloc.0
+  ldc.i4.1
+  ldloc.0
+  shl
+  stloc.1
+  ldloc.1
+  ldc.i4.1
+  sub.ovf
+  stloc.1
+  ldloc.1
+  ldc.i4.s 52
+  add.ovf
+  stloc.2
+  ldloc.2
+  ldc.i4.1
+  sub.ovf
+  pop
+  ldc.i8 0x0000000000000040
+  conv.ovf.i4
+  stloc.2
+  ldloc.2
+  ldc.i4.1
+  sub.ovf
+  stloc.2
+  ldloc.2
+  ldloc.1
+  add.ovf
+  pop
+  call string ['mscorlib']'System'.'Environment'::'get_NewLine'()
+  stsfld string '$'.'Globals'::'$csve'
+  ldsfld string '$'.'Globals'::'$csve'
+  ldnull
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_48
+  ldsfld string '$'.'Globals'::'$csve'
+  ldc.i4.s -2147483648
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 4
+  ldsfld string '$'.'Globals'::'$csve'
+  callvirt instance int32 ['mscorlib']'System'.'String'::'get_Length'()
+  stloc.1
+  ldloc.1
+  dup
+  ldc.i4.1
+  bne.un L_46
+  pop
+  ldloc.s 4
+  ldc.i4 10
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_45
+  ldloc.s 4
+  ldc.i4.s -1
+  ldc.i4.1
+  stsfld int32 '$'.'Globals'::'$csvk'
+  pop
+  pop
+  br _csvj
+L_45:
+  ldc.i4.s -1
+  ldc.i4.s -1
+  ldc.i4.s -2147483648
+  stsfld int32 '$'.'Globals'::'$csvk'
+  pop
+  pop
+  br _csvj
+L_46:
+  ldc.i4.2
+  bne.un L_47
+  ldsfld string '$'.'Globals'::'$csve'
+  ldc.i4.1
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 5
+  ldloc.s 4
+  ldloc.s 5
+  ldc.i4.2
+  stsfld int32 '$'.'Globals'::'$csvk'
+  pop
+  pop
+  br _csvj
+L_47:
+  ldstr " at TextIO:125.26-79"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "Unexpected line separator length"
+  newobj instance void '!'.'General'.'Fail'::.ctor(string)
+  throw
+_csvj:
+  call class ['mscorlib']'System'.'IO'.'TextReader' ['mscorlib']'System'.'Console'::'get_In'()
+  pop
+  call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Out'()
+  stsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$csvn'
+  call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Error'()
+  pop
+  ret
+L_48:
+  ldstr " at TextIO:118.20-68"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "No line separator available"
+  newobj instance void '!'.'General'.'Fail'::.ctor(string)
+  throw
+{.locals ([0] unsigned int32 /*csuy csuv*/ ,
+         [1] int32 /*csvi 'Real.eoffset' csuz csux csuw*/ ,
+         [2] int32 /*csvd 'Real.large_precision' 'Real.meoffset'*/ ,
+         [3] bool /*cswu cswx*/ ,
+         [4] char /*'TextIO.c'*/ ,
+         [5] char /*cswv*/ )}
+}
+.method static assembly void '$'() cil {
+.maxstack 0
+.zeroinit
+  ret
+{.locals ()}
+}
+.method static assembly void '.GCSafePoint'() managed noinlining {
+.maxstack 0
+.zeroinit
+  ret
+{.locals ()}
+}
+.method static assembly void 'TextIO.print'(string 'csvp') cil {
+.maxstack 3
+.zeroinit
+  ldsfld int32 '$'.'Globals'::'$csvk'
+  ldc.i4.s -2147483648
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_34
+  ldarg.0
+  callvirt instance int32 ['mscorlib']'System'.'String'::'get_Length'()
+  stloc.1
+  ldc.i4.s -2147483648
+  stloc.3
+_csvw:
+_csvx:
+  ldloc.3
+  ldloc.1
+  clt
+  stloc.0
+  ldloc.0
+  brtrue L_7
+L_2:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$csvn'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Flush'()
+  leave L_3
+L_3:
+  ret
+L_5:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "flushOut"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_6:
+L_4:
+  ret
+.try L_2 to L_3 catch ['mscorlib']'System'.'Exception' handler L_5 to L_6
+L_7:
+L_8:
+  ldarg.0
+  ldloc.3
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 4
+  leave L_9
+L_9:
+  ldloc.s 4
+  ldc.i4 10
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_20
+L_10:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$csvn'
+  ldloc.s 4
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(char)
+  leave L_11
+L_11:
+L_12:
+  ldloc.3
+  ldc.i4.1
+  add.ovf
+  stloc.3
+  leave L_13
+L_13:
+  br _csvx
+L_15:
+  stloc.2
+  leave _csvs
+L_16:
+L_14:
+  ret
+.try L_12 to L_13 catch ['mscorlib']'System'.'Exception' handler L_15 to L_16
+L_18:
+  stloc.2
+  leave _csvs
+L_19:
+L_17:
+  ret
+.try L_10 to L_11 catch ['mscorlib']'System'.'Exception' handler L_18 to L_19
+L_20:
+L_21:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$csvn'
+  ldsfld string '$'.'Globals'::'$csve'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(string)
+  leave L_22
+L_22:
+L_23:
+  ldloc.3
+  ldc.i4.1
+  add.ovf
+  stloc.3
+  leave L_24
+L_24:
+  br _csvx
+L_26:
+  stloc.2
+  leave _csvs
+L_27:
+L_25:
+  ret
+.try L_23 to L_24 catch ['mscorlib']'System'.'Exception' handler L_26 to L_27
+L_29:
+  stloc.2
+  leave _csvs
+L_30:
+L_28:
+  ret
+.try L_21 to L_22 catch ['mscorlib']'System'.'Exception' handler L_29 to L_30
+L_32:
+  stloc.2
+  leave _csvs
+L_33:
+L_31:
+  ret
+.try L_8 to L_9 catch ['mscorlib']'System'.'Exception' handler L_32 to L_33
+_csvs:
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "output"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_34:
+L_35:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$csvn'
+  ldarg.0
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(string)
+  leave L_36
+L_36:
+L_37:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$csvn'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Flush'()
+  leave L_38
+L_38:
+  ret
+L_40:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "flushOut"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_41:
+L_39:
+  ret
+.try L_37 to L_38 catch ['mscorlib']'System'.'Exception' handler L_40 to L_41
+L_43:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "output"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_44:
+L_42:
+  ret
+.try L_35 to L_36 catch ['mscorlib']'System'.'Exception' handler L_43 to L_44
+{.locals ([0] bool /*cswf csvz csvq*/ ,
+         [1] int32 /*'CharVector.stop'*/ ,
+         [2] class ['mscorlib']'System'.'Exception' /*cswm cswp cswd cswj cswk cswg cswh cswa csvt*/ ,
+         [3] int32 /*cswl cswi csvy*/ ,
+         [4] char /*cswe*/ )}
+}
+
+}
+}

--- a/test/Regression2.sml
+++ b/test/Regression2.sml
@@ -1,0 +1,10 @@
+
+structure Regression2 = struct
+  fun main () =
+    let
+      val f = ref (print "hello\n")
+      val () = f := print "world\n"
+    in
+      ()
+    end
+end

--- a/test/Regression3.il.expected
+++ b/test/Regression3.il.expected
@@ -1,0 +1,642 @@
+.assembly extern mscorlib {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 4:0:0:0
+}
+.assembly extern Accessibility {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Configuration.Install {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Data {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.DirectoryServices {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.Drawing {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.EnterpriseServices {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Management {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Messaging {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Runtime.Remoting {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.Runtime.Serialization.Formatters.Soap {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Security {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.ServiceProcess {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern Mono.Unix {
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )
+  .ver 7:1:0:0
+}
+.assembly 'Regression3'
+{ .hash algorithm 0x00008004 }
+.module 'Regression3.exe'
+
+.namespace '$' {
+.class  private sealed 'Tuple1_a' extends ['mscorlib']'System'.'Object'{
+
+.field assembly int32 '_1'
+.method assembly instance void '.ctor'(int32 '_1') cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ldarg.0
+  ldarg.1
+  stfld int32 '$'.'Tuple1_a'::'_1'
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private sealed 'Tuple1_b' extends ['mscorlib']'System'.'Object'{
+
+.field assembly class '$'.'Tuple1_a' '_1'
+.method assembly instance void '.ctor'(class '$'.'Tuple1_a' '_1') cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ldarg.0
+  ldarg.1
+  stfld class '$'.'Tuple1_a' '$'.'Tuple1_b'::'_1'
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private abstract 'Class_a' extends ['mscorlib']'System'.'Exception'{
+
+.field private initonly string 's'
+.method public instance void '.ctor'(string 's') cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  ldarg.1
+  call instance instance void ['mscorlib']'System'.'Exception'::'.ctor'(string)
+  ldarg.0
+  ldarg.1
+  stfld string '$'.'Class_a'::'s'
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ToString'() cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  callvirt instance string '$'.'Class_a'::'ExnMessage'()
+  stloc.0
+  ldsfld string '$'.'Globals'::'$l'
+  stloc.1
+  ldloc.1
+  ldnull
+  ceq
+  stloc.2
+  ldloc.2
+  brtrue L_1
+  ldloc.0
+  ldloc.1
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldloc.0
+  ret
+L_1:
+  ldloc.0
+  ret
+{.locals ([0] string /*ctcj 'PrimUtils_.prefix'*/ ,
+         [1] string /*ctch*/ ,
+         [2] bool /*ctez*/ )}
+}
+.method public virtual instance string 'ExnMessage'() cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  callvirt instance string '$'.'Class_a'::'ExnName'()
+  stloc.0
+  ldloc.0
+  ldstr ": "
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldarg.0
+  callvirt instance string ['mscorlib']'System'.'Exception'::'get_Message'()
+  stloc.1
+  ldloc.0
+  ldloc.1
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldloc.0
+  ret
+{.locals ([0] string /*ctcp ctcn ctcm*/ ,
+         [1] string /*ctco*/ )}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 1
+.zeroinit
+  ldstr "SML exception"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.class  public sealed 'Regression3' extends ['mscorlib']'System'.'Object'{
+
+.method public static void '.cctor'() cil {
+.maxstack 0
+.zeroinit
+  call void '$'.'Globals'::'$'()
+  ret
+{.locals ()}
+}
+.method public static void 'main'() cil {
+.maxstack 2
+.zeroinit
+.entrypoint
+  ldstr bytearray (68 00 65 00 6C 00 6C 00 6F 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldsfld class '$'.'Tuple1_a' '$'.'Globals'::'$ctep'
+  newobj instance void '$'.'Tuple1_b'::.ctor(class '$'.'Tuple1_a')
+  stloc.0
+  ldloc.0
+  ldsfld class '$'.'Tuple1_a' '$'.'Globals'::'$cteq'
+  stfld class '$'.'Tuple1_a' '$'.'Tuple1_b'::'_1'
+  ldsfld class '$'.'Tuple1_a' '$'.'Globals'::'$ctep'
+  newobj instance void '$'.'Tuple1_b'::.ctor(class '$'.'Tuple1_a')
+  stloc.0
+  ldstr bytearray (77 00 6F 00 72 00 6C 00 64 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldloc.0
+  ldsfld class '$'.'Tuple1_a' '$'.'Globals'::'$cteq'
+  stfld class '$'.'Tuple1_a' '$'.'Tuple1_b'::'_1'
+  ret
+{.locals ([0] class '$'.'Tuple1_b' /*'Regression3.h' 'Regression3.g'*/ )}
+}
+
+}
+
+.namespace '$' {
+.class  private 'Fun' extends ['mscorlib']'System'.'Object'{
+
+.method assembly instance void '.ctor'() cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private sealed 'Tuple3_a' extends ['mscorlib']'System'.'Object'{
+
+.field assembly string '_1'
+.field assembly class ['mscorlib']'System'.'Exception' '_2'
+.field assembly string '_3'
+.method assembly instance void '.ctor'(string '_1',class ['mscorlib']'System'.'Exception' '_2',string '_3') cil {
+.maxstack 4
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ldarg.0
+  ldarg.1
+  stfld string '$'.'Tuple3_a'::'_1'
+  ldarg.0
+  ldarg.2
+  stfld class ['mscorlib']'System'.'Exception' '$'.'Tuple3_a'::'_2'
+  ldarg.0
+  ldarg.3
+  stfld string '$'.'Tuple3_a'::'_3'
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'IO' {
+.class  private sealed 'Io' extends '$'.'Class_a'{
+
+.field assembly class '$'.'Tuple3_a' '_1'
+.method assembly instance void '.ctor'(class '$'.'Tuple3_a' '') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldnull
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ldarg.0
+  ldarg.1
+  stfld class '$'.'Tuple3_a' '!'.'IO'.'Io'::'_1'
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "IO.Io"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'General' {
+.class  private sealed 'Fail' extends '$'.'Class_a'{
+
+.method assembly instance void '.ctor'(string '') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldarg.1
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "General.Fail"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private 'Globals' extends ['mscorlib']'System'.'Object'{
+
+.field static assembly string '$l'
+.field static assembly int32 '$g'
+.field static assembly string '$ctdb'
+.field static assembly int32 '$ctdh'
+.field static assembly class ['mscorlib']'System'.'IO'.'TextWriter' '$ctdk'
+.field static assembly class '$'.'Tuple1_a' '$ctep'
+.field static assembly class '$'.'Tuple1_a' '$cteq'
+.method static assembly void '.cctor'() cil {
+.maxstack 3
+.zeroinit
+  ldc.i4.s 11
+  conv.u4
+  stloc.0
+  ldc.i4.1
+  ldloc.0
+  shl
+  stloc.1
+  ldloc.1
+  ldc.i4.1
+  sub.ovf
+  pop
+  ldc.i4.s 11
+  ldc.i4.1
+  sub.ovf
+  stloc.1
+  ldloc.1
+  conv.u4
+  stloc.0
+  ldc.i4.1
+  ldloc.0
+  shl
+  stloc.1
+  ldloc.1
+  ldc.i4.1
+  sub.ovf
+  stloc.1
+  ldloc.1
+  ldc.i4.s 52
+  add.ovf
+  stloc.2
+  ldloc.2
+  ldc.i4.1
+  sub.ovf
+  pop
+  ldc.i8 0x0000000000000040
+  conv.ovf.i4
+  stloc.2
+  ldloc.2
+  ldc.i4.1
+  sub.ovf
+  stloc.2
+  ldloc.2
+  ldloc.1
+  add.ovf
+  pop
+  call string ['mscorlib']'System'.'Environment'::'get_NewLine'()
+  stsfld string '$'.'Globals'::'$ctdb'
+  ldsfld string '$'.'Globals'::'$ctdb'
+  ldnull
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_48
+  ldsfld string '$'.'Globals'::'$ctdb'
+  ldc.i4.s -2147483648
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 4
+  ldsfld string '$'.'Globals'::'$ctdb'
+  callvirt instance int32 ['mscorlib']'System'.'String'::'get_Length'()
+  stloc.1
+  ldloc.1
+  dup
+  ldc.i4.1
+  bne.un L_46
+  pop
+  ldloc.s 4
+  ldc.i4 10
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_45
+  ldloc.s 4
+  ldc.i4.s -1
+  ldc.i4.1
+  stsfld int32 '$'.'Globals'::'$ctdh'
+  pop
+  pop
+  br _ctdg
+L_45:
+  ldc.i4.s -1
+  ldc.i4.s -1
+  ldc.i4.s -2147483648
+  stsfld int32 '$'.'Globals'::'$ctdh'
+  pop
+  pop
+  br _ctdg
+L_46:
+  ldc.i4.2
+  bne.un L_47
+  ldsfld string '$'.'Globals'::'$ctdb'
+  ldc.i4.1
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 5
+  ldloc.s 4
+  ldloc.s 5
+  ldc.i4.2
+  stsfld int32 '$'.'Globals'::'$ctdh'
+  pop
+  pop
+  br _ctdg
+L_47:
+  ldstr " at TextIO:125.26-79"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "Unexpected line separator length"
+  newobj instance void '!'.'General'.'Fail'::.ctor(string)
+  throw
+_ctdg:
+  call class ['mscorlib']'System'.'IO'.'TextReader' ['mscorlib']'System'.'Console'::'get_In'()
+  pop
+  call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Out'()
+  stsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$ctdk'
+  call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Error'()
+  pop
+  ldc.i4.1
+  newobj instance void '$'.'Tuple1_a'::.ctor(int32)
+  stsfld class '$'.'Tuple1_a' '$'.'Globals'::'$ctep'
+  ldc.i4.2
+  newobj instance void '$'.'Tuple1_a'::.ctor(int32)
+  stsfld class '$'.'Tuple1_a' '$'.'Globals'::'$cteq'
+  ret
+L_48:
+  ldstr " at TextIO:118.20-68"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "No line separator available"
+  newobj instance void '!'.'General'.'Fail'::.ctor(string)
+  throw
+{.locals ([0] unsigned int32 /*ctcv ctcs*/ ,
+         [1] int32 /*ctdf 'Real.eoffset' ctcw ctcu ctct*/ ,
+         [2] int32 /*ctda 'Real.large_precision' 'Real.meoffset'*/ ,
+         [3] bool /*ctev ctey*/ ,
+         [4] char /*'TextIO.c'*/ ,
+         [5] char /*ctew*/ )}
+}
+.method static assembly void '$'() cil {
+.maxstack 0
+.zeroinit
+  ret
+{.locals ()}
+}
+.method static assembly void '.GCSafePoint'() managed noinlining {
+.maxstack 0
+.zeroinit
+  ret
+{.locals ()}
+}
+.method static assembly void 'TextIO.print'(string 'ctdm') cil {
+.maxstack 3
+.zeroinit
+  ldsfld int32 '$'.'Globals'::'$ctdh'
+  ldc.i4.s -2147483648
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_34
+  ldarg.0
+  callvirt instance int32 ['mscorlib']'System'.'String'::'get_Length'()
+  stloc.1
+  ldc.i4.s -2147483648
+  stloc.3
+_ctdt:
+_ctdu:
+  ldloc.3
+  ldloc.1
+  clt
+  stloc.0
+  ldloc.0
+  brtrue L_7
+L_2:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$ctdk'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Flush'()
+  leave L_3
+L_3:
+  ret
+L_5:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "flushOut"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_6:
+L_4:
+  ret
+.try L_2 to L_3 catch ['mscorlib']'System'.'Exception' handler L_5 to L_6
+L_7:
+L_8:
+  ldarg.0
+  ldloc.3
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 4
+  leave L_9
+L_9:
+  ldloc.s 4
+  ldc.i4 10
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_20
+L_10:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$ctdk'
+  ldloc.s 4
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(char)
+  leave L_11
+L_11:
+L_12:
+  ldloc.3
+  ldc.i4.1
+  add.ovf
+  stloc.3
+  leave L_13
+L_13:
+  br _ctdu
+L_15:
+  stloc.2
+  leave _ctdp
+L_16:
+L_14:
+  ret
+.try L_12 to L_13 catch ['mscorlib']'System'.'Exception' handler L_15 to L_16
+L_18:
+  stloc.2
+  leave _ctdp
+L_19:
+L_17:
+  ret
+.try L_10 to L_11 catch ['mscorlib']'System'.'Exception' handler L_18 to L_19
+L_20:
+L_21:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$ctdk'
+  ldsfld string '$'.'Globals'::'$ctdb'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(string)
+  leave L_22
+L_22:
+L_23:
+  ldloc.3
+  ldc.i4.1
+  add.ovf
+  stloc.3
+  leave L_24
+L_24:
+  br _ctdu
+L_26:
+  stloc.2
+  leave _ctdp
+L_27:
+L_25:
+  ret
+.try L_23 to L_24 catch ['mscorlib']'System'.'Exception' handler L_26 to L_27
+L_29:
+  stloc.2
+  leave _ctdp
+L_30:
+L_28:
+  ret
+.try L_21 to L_22 catch ['mscorlib']'System'.'Exception' handler L_29 to L_30
+L_32:
+  stloc.2
+  leave _ctdp
+L_33:
+L_31:
+  ret
+.try L_8 to L_9 catch ['mscorlib']'System'.'Exception' handler L_32 to L_33
+_ctdp:
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "output"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_34:
+L_35:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$ctdk'
+  ldarg.0
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(string)
+  leave L_36
+L_36:
+L_37:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$ctdk'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Flush'()
+  leave L_38
+L_38:
+  ret
+L_40:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "flushOut"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_41:
+L_39:
+  ret
+.try L_37 to L_38 catch ['mscorlib']'System'.'Exception' handler L_40 to L_41
+L_43:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "output"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_44:
+L_42:
+  ret
+.try L_35 to L_36 catch ['mscorlib']'System'.'Exception' handler L_43 to L_44
+{.locals ([0] bool /*ctec ctdw ctdn*/ ,
+         [1] int32 /*'CharVector.stop'*/ ,
+         [2] class ['mscorlib']'System'.'Exception' /*ctej ctem ctea cteg cteh cted ctee ctdx ctdq*/ ,
+         [3] int32 /*ctei ctef ctdv*/ ,
+         [4] char /*cteb*/ )}
+}
+
+}
+}

--- a/test/Regression3.sml
+++ b/test/Regression3.sml
@@ -1,0 +1,14 @@
+structure Regression3 = struct
+  fun main () =
+    let
+      val f = ref ()
+      val g = ref (print "hello\n")
+      val () = f := !g
+      val g = ref ((), 1, ())
+      val () = g := ((), 2, ())
+      val h = ref { a = (), b = 1, c = () }
+      val () = h := { a = (), b = 2, c = (print "world\n"; ()) }
+    in
+      ()
+    end
+end

--- a/test/Regression4.il.expected
+++ b/test/Regression4.il.expected
@@ -1,0 +1,1256 @@
+.assembly extern mscorlib {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 4:0:0:0
+}
+.assembly extern Accessibility {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Configuration.Install {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Data {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.DirectoryServices {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.Drawing {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.EnterpriseServices {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Management {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Messaging {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Runtime.Remoting {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.Runtime.Serialization.Formatters.Soap {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Security {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.ServiceProcess {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern Mono.Unix {
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )
+  .ver 7:1:0:0
+}
+.assembly 'Regression4'
+{ .hash algorithm 0x00008004 }
+.module 'Regression4.exe'
+
+.namespace '$' {
+.class  private abstract 'Class_a' extends ['mscorlib']'System'.'Exception'{
+
+.field private initonly string 's'
+.method public instance void '.ctor'(string 's') cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  ldarg.1
+  call instance instance void ['mscorlib']'System'.'Exception'::'.ctor'(string)
+  ldarg.0
+  ldarg.1
+  stfld string '$'.'Class_a'::'s'
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ToString'() cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  callvirt instance string '$'.'Class_a'::'ExnMessage'()
+  stloc.0
+  ldsfld string '$'.'Globals'::'$l'
+  stloc.1
+  ldloc.1
+  ldnull
+  ceq
+  stloc.2
+  ldloc.2
+  brtrue L_1
+  ldloc.0
+  ldloc.1
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldloc.0
+  ret
+L_1:
+  ldloc.0
+  ret
+{.locals ([0] string /*cxmq 'PrimUtils_.prefix'*/ ,
+         [1] string /*cxmo*/ ,
+         [2] bool /*cxud*/ )}
+}
+.method public virtual instance string 'ExnMessage'() cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  callvirt instance string '$'.'Class_a'::'ExnName'()
+  stloc.0
+  ldloc.0
+  ldstr ": "
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldarg.0
+  callvirt instance string ['mscorlib']'System'.'Exception'::'get_Message'()
+  stloc.1
+  ldloc.0
+  ldloc.1
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldloc.0
+  ret
+{.locals ([0] string /*cxmw cxmu cxmt*/ ,
+         [1] string /*cxmv*/ )}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 1
+.zeroinit
+  ldstr "SML exception"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.class  public sealed 'Regression4' extends ['mscorlib']'System'.'Object'{
+
+.method public static void '.cctor'() cil {
+.maxstack 0
+.zeroinit
+  call void '$'.'Globals'::'$'()
+  ret
+{.locals ()}
+}
+.method public static void 'testLong'() cil {
+.maxstack 0
+.zeroinit
+  tail.
+  call void '$'.'Globals'::'Regression4.testLong'()
+  ret
+{.locals ()}
+}
+.method public static void 'testInt'() cil {
+.maxstack 0
+.zeroinit
+  tail.
+  call void '$'.'Globals'::'Regression4.testInt'()
+  ret
+{.locals ()}
+}
+.method public static void 'main'() cil {
+.maxstack 1
+.zeroinit
+.entrypoint
+  ldstr bytearray (54 00 65 00 73 00 74 00 69 00 6E 00 67 00 20 00 69 00 6E 00 74 00 73 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  call void '$'.'Globals'::'Regression4.testInt'()
+  ldstr bytearray (54 00 65 00 73 00 74 00 69 00 6E 00 67 00 20 00 6C 00 6F 00 6E 00 67 00 73 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  tail.
+  call void '$'.'Globals'::'Regression4.testLong'()
+  ret
+{.locals ()}
+}
+.method public static int64 'J\047'(int64 'cxtl') cil {
+.maxstack 1
+.zeroinit
+  ldarg.0
+  neg
+  starg.s 0
+  ldstr bytearray (52 00 75 00 6E 00 6E 00 69 00 6E 00 67 00 20 00 4A 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldarg.0
+  ret
+{.locals ()}
+}
+.method public static int64 'I\047'(int64 'cxto') cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  ldc.i8 0x0000000000000001
+  sub
+  starg.s 0
+  ldstr bytearray (52 00 75 00 6E 00 6E 00 69 00 6E 00 67 00 20 00 49 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldarg.0
+  ret
+{.locals ()}
+}
+.method public static int32 'J'(int32 'cxtr') cil {
+.maxstack 1
+.zeroinit
+  ldarg.0
+  neg
+  starg.s 0
+  ldstr bytearray (52 00 75 00 6E 00 6E 00 69 00 6E 00 67 00 20 00 4A 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldarg.0
+  ret
+{.locals ()}
+}
+.method public static int32 'I'(int32 'cxtu') cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  ldc.i4.1
+  sub.ovf
+  starg.s 0
+  ldstr bytearray (52 00 75 00 6E 00 6E 00 69 00 6E 00 67 00 20 00 49 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldarg.0
+  ret
+{.locals ()}
+}
+
+}
+
+.namespace '$' {
+.class  private 'Fun' extends ['mscorlib']'System'.'Object'{
+
+.method assembly instance void '.ctor'() cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private sealed 'Tuple2_a' extends ['mscorlib']'System'.'Object'{
+
+.field assembly char '_1'
+.field assembly class '$'.'Tuple2_a' '_2'
+.method assembly instance void '.ctor'(char '_1',class '$'.'Tuple2_a' '_2') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ldarg.0
+  ldarg.1
+  stfld char '$'.'Tuple2_a'::'_1'
+  ldarg.0
+  ldarg.2
+  stfld class '$'.'Tuple2_a' '$'.'Tuple2_a'::'_2'
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private sealed 'Tuple3_a' extends ['mscorlib']'System'.'Object'{
+
+.field assembly string '_1'
+.field assembly class ['mscorlib']'System'.'Exception' '_2'
+.field assembly string '_3'
+.method assembly instance void '.ctor'(string '_1',class ['mscorlib']'System'.'Exception' '_2',string '_3') cil {
+.maxstack 4
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ldarg.0
+  ldarg.1
+  stfld string '$'.'Tuple3_a'::'_1'
+  ldarg.0
+  ldarg.2
+  stfld class ['mscorlib']'System'.'Exception' '$'.'Tuple3_a'::'_2'
+  ldarg.0
+  ldarg.3
+  stfld string '$'.'Tuple3_a'::'_3'
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'IO' {
+.class  private sealed 'Io' extends '$'.'Class_a'{
+
+.field assembly class '$'.'Tuple3_a' '_1'
+.method assembly instance void '.ctor'(class '$'.'Tuple3_a' '') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldnull
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ldarg.0
+  ldarg.1
+  stfld class '$'.'Tuple3_a' '!'.'IO'.'Io'::'_1'
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "IO.Io"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'PrimUtils_'.'Char' {
+.class  private sealed 'Chr' extends '$'.'Class_a'{
+
+.method assembly instance void '.ctor'() cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldnull
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "PrimUtils_.Char.Chr"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'General' {
+.class  private sealed 'Fail' extends '$'.'Class_a'{
+
+.method assembly instance void '.ctor'(string '') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldarg.1
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "General.Fail"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private 'Globals' extends ['mscorlib']'System'.'Object'{
+
+.field static assembly string '$l'
+.field static assembly int32 '$g'
+.field static assembly class ['mscorlib']'System'.'Exception' '$cxmc'
+.field static assembly string '$cxqf'
+.field static assembly int32 '$cxql'
+.field static assembly class ['mscorlib']'System'.'IO'.'TextWriter' '$cxqo'
+.method static assembly void '.cctor'() cil {
+.maxstack 3
+.zeroinit
+  newobj instance void '!'.'PrimUtils_'.'Char'.'Chr'::.ctor()
+  stsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cxmc'
+  ldc.i4.s 11
+  conv.u4
+  stloc.0
+  ldc.i4.1
+  ldloc.0
+  shl
+  stloc.1
+  ldloc.1
+  ldc.i4.1
+  sub.ovf
+  pop
+  ldc.i4.s 11
+  ldc.i4.1
+  sub.ovf
+  stloc.1
+  ldloc.1
+  conv.u4
+  stloc.0
+  ldc.i4.1
+  ldloc.0
+  shl
+  stloc.1
+  ldloc.1
+  ldc.i4.1
+  sub.ovf
+  stloc.1
+  ldloc.1
+  ldc.i4.s 52
+  add.ovf
+  stloc.2
+  ldloc.2
+  ldc.i4.1
+  sub.ovf
+  pop
+  ldc.i8 0x0000000000000040
+  conv.ovf.i4
+  stloc.2
+  ldloc.2
+  ldc.i4.1
+  sub.ovf
+  stloc.2
+  ldloc.2
+  ldloc.1
+  add.ovf
+  pop
+  call string ['mscorlib']'System'.'Environment'::'get_NewLine'()
+  stsfld string '$'.'Globals'::'$cxqf'
+  ldsfld string '$'.'Globals'::'$cxqf'
+  ldnull
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_69
+  ldsfld string '$'.'Globals'::'$cxqf'
+  ldc.i4.s -2147483648
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 4
+  ldsfld string '$'.'Globals'::'$cxqf'
+  callvirt instance int32 ['mscorlib']'System'.'String'::'get_Length'()
+  stloc.1
+  ldloc.1
+  dup
+  ldc.i4.1
+  bne.un L_67
+  pop
+  ldloc.s 4
+  ldc.i4 10
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_66
+  ldloc.s 4
+  ldc.i4.s -1
+  ldc.i4.1
+  stsfld int32 '$'.'Globals'::'$cxql'
+  pop
+  pop
+  br _cxqk
+L_66:
+  ldc.i4.s -1
+  ldc.i4.s -1
+  ldc.i4.s -2147483648
+  stsfld int32 '$'.'Globals'::'$cxql'
+  pop
+  pop
+  br _cxqk
+L_67:
+  ldc.i4.2
+  bne.un L_68
+  ldsfld string '$'.'Globals'::'$cxqf'
+  ldc.i4.1
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 5
+  ldloc.s 4
+  ldloc.s 5
+  ldc.i4.2
+  stsfld int32 '$'.'Globals'::'$cxql'
+  pop
+  pop
+  br _cxqk
+L_68:
+  ldstr " at TextIO:125.26-79"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "Unexpected line separator length"
+  newobj instance void '!'.'General'.'Fail'::.ctor(string)
+  throw
+_cxqk:
+  call class ['mscorlib']'System'.'IO'.'TextReader' ['mscorlib']'System'.'Console'::'get_In'()
+  pop
+  call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Out'()
+  stsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Error'()
+  pop
+  ret
+L_69:
+  ldstr " at TextIO:118.20-68"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "No line separator available"
+  newobj instance void '!'.'General'.'Fail'::.ctor(string)
+  throw
+{.locals ([0] unsigned int32 /*cxpz cxpw*/ ,
+         [1] int32 /*cxqj 'Real.eoffset' cxqa cxpy cxpx*/ ,
+         [2] int32 /*cxqe 'Real.large_precision' 'Real.meoffset'*/ ,
+         [3] bool /*cxtw cxuc*/ ,
+         [4] char /*'TextIO.c'*/ ,
+         [5] char /*cxtx*/ )}
+}
+.method static assembly void '$'() cil {
+.maxstack 0
+.zeroinit
+  ret
+{.locals ()}
+}
+.method static assembly void '.GCSafePoint'() managed noinlining {
+.maxstack 0
+.zeroinit
+  ret
+{.locals ()}
+}
+.method static assembly char 'PrimUtils_.chr'(int32 'cxmf') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldc.i4.s -2147483648
+  clt
+  stloc.0
+  ldloc.0
+  brtrue L_3
+  ldarg.0
+  ldc.i4 65535
+  cgt
+  stloc.0
+  ldloc.0
+  brtrue L_2
+  ldarg.0
+  ret
+L_2:
+  ldstr " at PrimUtils_:579.9-18"
+  stsfld string '$'.'Globals'::'$l'
+  ldsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cxmc'
+  throw
+L_3:
+  ldstr " at PrimUtils_:579.9-18"
+  stsfld string '$'.'Globals'::'$l'
+  ldsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cxmc'
+  throw
+{.locals ([0] bool /*cxmh cxmg*/ )}
+}
+.method static assembly string 'Utils_.implode'(class '$'.'Tuple2_a' 'cxna') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldnull
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_6
+  ldarg.0
+  ldfld class '$'.'Tuple2_a' '$'.'Tuple2_a'::'_2'
+  ldnull
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_5
+  newobj instance void ['mscorlib']'System'.'Text'.'StringBuilder'::.ctor()
+  stloc.1
+_cxnf:
+_cxng:
+  ldarg.0
+  ldnull
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_4
+  ldloc.1
+  ldarg.0
+  ldfld char '$'.'Tuple2_a'::'_1'
+  callvirt instance class ['mscorlib']'System'.'Text'.'StringBuilder' ['mscorlib']'System'.'Text'.'StringBuilder'::'Append'(char)
+  pop
+  ldarg.0
+  ldfld class '$'.'Tuple2_a' '$'.'Tuple2_a'::'_2'
+  starg.s 0
+  br _cxng
+L_4:
+  ldloc.1
+  callvirt instance string ['mscorlib']'System'.'Text'.'StringBuilder'::'ToString'()
+  stloc.2
+  ldloc.2
+  ret
+L_5:
+  ldarg.0
+  ldfld char '$'.'Tuple2_a'::'_1'
+  call string ['mscorlib']'System'.'Char'::'ToString'(char)
+  stloc.2
+  ldloc.2
+  ret
+L_6:
+  ldstr ""
+  ret
+{.locals ([0] bool /*cxtz cxua cxub*/ ,
+         [1] class ['mscorlib']'System'.'Text'.'StringBuilder' /*'Utils_.sb'*/ ,
+         [2] string /*cxnn cxnl*/ )}
+}
+.method static assembly string '$cxno'(int32 'cxnp') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldc.i4.s -2147483648
+  clt
+  stloc.0
+  ldarg.0
+  ldc.i4.s -2147483648
+  ceq
+  stloc.2
+  ldloc.2
+  brtrue L_13
+  ldarg.0
+  ldnull
+  stloc.1
+  starg.s 0
+  br _cxnr
+L_13:
+  ldstr "0"
+  ret
+_cxnr:
+_cxns:
+  ldarg.0
+  ldc.i4.s -2147483648
+  ceq
+  stloc.2
+  ldloc.2
+  brtrue L_11
+  ldarg.0
+  ldc.i4.s 10
+  div
+  pop
+  ldarg.0
+  ldc.i4.s -2147483648
+  ceq
+  stloc.2
+  ldloc.2
+  brtrue L_9
+  ldarg.0
+  ldc.i4.s 10
+  div
+  stloc.3
+  ldarg.0
+  ldc.i4.s 10
+  rem
+  starg.s 0
+  ldarg.0
+  ldc.i4.s -2147483648
+  clt
+  stloc.2
+  ldloc.2
+  brtrue L_8
+  br _cxoa
+L_8:
+  ldarg.0
+  neg
+  starg.s 0
+_cxoa:
+  ldarg.0
+  ldc.i4.s 10
+  clt
+  stloc.2
+  ldloc.2
+  brtrue L_7
+  ldc.i4 65
+  ldc.i4.s 10
+  sub.ovf
+  stloc.s 4
+  ldloc.s 4
+  ldarg.0
+  add.ovf
+  starg.s 0
+  ldarg.0
+  call char '$'.'Globals'::'PrimUtils_.chr'(int32)
+  stloc.s 5
+  ldloc.3
+  ldloc.s 5
+  ldloc.1
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  stloc.1
+  starg.s 0
+  br _cxns
+L_7:
+  ldc.i4 48
+  ldarg.0
+  add.ovf
+  starg.s 0
+  ldarg.0
+  call char '$'.'Globals'::'PrimUtils_.chr'(int32)
+  stloc.s 5
+  ldloc.3
+  ldloc.s 5
+  ldloc.1
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  stloc.1
+  starg.s 0
+  br _cxns
+L_9:
+  ldarg.0
+  ldc.i4.s 10
+  rem
+  starg.s 0
+  ldarg.0
+  ldc.i4.s -2147483648
+  clt
+  stloc.2
+  ldloc.2
+  brtrue L_10
+  br _cxns
+L_10:
+  ldarg.0
+  neg
+  starg.s 0
+  br _cxns
+L_11:
+  ldloc.0
+  brtrue L_12
+  ldloc.1
+  tail.
+  call string '$'.'Globals'::'Utils_.implode'(class '$'.'Tuple2_a')
+  ret
+L_12:
+  ldc.i4 126
+  ldloc.1
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  tail.
+  call string '$'.'Globals'::'Utils_.implode'(class '$'.'Tuple2_a')
+  ret
+{.locals ([0] bool /*'Utils_.negative'*/ ,
+         [1] class '$'.'Tuple2_a' /*cxnt*/ ,
+         [2] bool /*cxop cxom cxoc cxnz cxnw cxnv*/ ,
+         [3] int32 /*cxnx*/ ,
+         [4] int32 /*cxod*/ ,
+         [5] char /*cxoi cxof*/ )}
+}
+.method static assembly string '$cxoq'(int64 'cxor') cil {
+.maxstack 3
+.zeroinit
+  ldc.i4.s 10
+  conv.i8
+  stloc.0
+  ldarg.0
+  ldc.i8 0x0000000000000000
+  clt
+  stloc.1
+  ldarg.0
+  ldc.i8 0x0000000000000000
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_20
+  ldarg.0
+  ldnull
+  stloc.2
+  starg.s 0
+  br _cxou
+L_20:
+  ldstr "0"
+  ret
+_cxou:
+_cxov:
+  ldarg.0
+  ldc.i8 0x0000000000000000
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_18
+  ldarg.0
+  ldloc.0
+  div
+  pop
+  ldarg.0
+  ldc.i8 0x0000000000000000
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_16
+  ldarg.0
+  ldloc.0
+  div
+  stloc.s 4
+  ldarg.0
+  ldloc.0
+  rem
+  starg.s 0
+  ldarg.0
+  ldc.i8 0x0000000000000000
+  clt
+  stloc.3
+  ldloc.3
+  brtrue L_15
+  br _cxpd
+L_15:
+  ldarg.0
+  neg
+  starg.s 0
+_cxpd:
+  ldarg.0
+  conv.ovf.i4
+  stloc.s 5
+  ldloc.s 5
+  ldc.i4.s 10
+  clt
+  stloc.3
+  ldloc.3
+  brtrue L_14
+  ldc.i4 65
+  ldc.i4.s 10
+  sub.ovf
+  stloc.s 5
+  ldarg.0
+  conv.ovf.i4
+  stloc.s 6
+  ldloc.s 5
+  ldloc.s 6
+  add.ovf
+  stloc.s 5
+  ldloc.s 5
+  call char '$'.'Globals'::'PrimUtils_.chr'(int32)
+  stloc.s 7
+  ldloc.s 4
+  ldloc.s 7
+  ldloc.2
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  stloc.2
+  starg.s 0
+  br _cxov
+L_14:
+  ldarg.0
+  conv.ovf.i4
+  stloc.s 5
+  ldc.i4 48
+  ldloc.s 5
+  add.ovf
+  stloc.s 5
+  ldloc.s 5
+  call char '$'.'Globals'::'PrimUtils_.chr'(int32)
+  stloc.s 7
+  ldloc.s 4
+  ldloc.s 7
+  ldloc.2
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  stloc.2
+  starg.s 0
+  br _cxov
+L_16:
+  ldarg.0
+  ldloc.0
+  rem
+  starg.s 0
+  ldarg.0
+  ldc.i8 0x0000000000000000
+  clt
+  stloc.3
+  ldloc.3
+  brtrue L_17
+  br _cxov
+L_17:
+  ldarg.0
+  neg
+  starg.s 0
+  br _cxov
+L_18:
+  ldloc.1
+  brtrue L_19
+  ldloc.2
+  tail.
+  call string '$'.'Globals'::'Utils_.implode'(class '$'.'Tuple2_a')
+  ret
+L_19:
+  ldc.i4 126
+  ldloc.2
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  tail.
+  call string '$'.'Globals'::'Utils_.implode'(class '$'.'Tuple2_a')
+  ret
+{.locals ([0] int64 /*'Utils_.base'*/ ,
+         [1] bool /*'Utils_.negative'*/ ,
+         [2] class '$'.'Tuple2_a' /*cxow*/ ,
+         [3] bool /*cxpv cxps cxpg cxpc cxoz cxoy*/ ,
+         [4] int64 /*cxpa*/ ,
+         [5] int32 /*cxpn cxpm cxpj cxph cxpf*/ ,
+         [6] int32 /*cxpi*/ ,
+         [7] char /*cxpo cxpk*/ )}
+}
+.method static assembly void 'TextIO.print'(string 'cxqq') cil {
+.maxstack 3
+.zeroinit
+  ldsfld int32 '$'.'Globals'::'$cxql'
+  ldc.i4.s -2147483648
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_53
+  ldarg.0
+  callvirt instance int32 ['mscorlib']'System'.'String'::'get_Length'()
+  stloc.1
+  ldc.i4.s -2147483648
+  stloc.3
+_cxqx:
+_cxqy:
+  ldloc.3
+  ldloc.1
+  clt
+  stloc.0
+  ldloc.0
+  brtrue L_26
+L_21:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Flush'()
+  leave L_22
+L_22:
+  ret
+L_24:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "flushOut"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_25:
+L_23:
+  ret
+.try L_21 to L_22 catch ['mscorlib']'System'.'Exception' handler L_24 to L_25
+L_26:
+L_27:
+  ldarg.0
+  ldloc.3
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 4
+  leave L_28
+L_28:
+  ldloc.s 4
+  ldc.i4 10
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_39
+L_29:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  ldloc.s 4
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(char)
+  leave L_30
+L_30:
+L_31:
+  ldloc.3
+  ldc.i4.1
+  add.ovf
+  stloc.3
+  leave L_32
+L_32:
+  br _cxqy
+L_34:
+  stloc.2
+  leave _cxqt
+L_35:
+L_33:
+  ret
+.try L_31 to L_32 catch ['mscorlib']'System'.'Exception' handler L_34 to L_35
+L_37:
+  stloc.2
+  leave _cxqt
+L_38:
+L_36:
+  ret
+.try L_29 to L_30 catch ['mscorlib']'System'.'Exception' handler L_37 to L_38
+L_39:
+L_40:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  ldsfld string '$'.'Globals'::'$cxqf'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(string)
+  leave L_41
+L_41:
+L_42:
+  ldloc.3
+  ldc.i4.1
+  add.ovf
+  stloc.3
+  leave L_43
+L_43:
+  br _cxqy
+L_45:
+  stloc.2
+  leave _cxqt
+L_46:
+L_44:
+  ret
+.try L_42 to L_43 catch ['mscorlib']'System'.'Exception' handler L_45 to L_46
+L_48:
+  stloc.2
+  leave _cxqt
+L_49:
+L_47:
+  ret
+.try L_40 to L_41 catch ['mscorlib']'System'.'Exception' handler L_48 to L_49
+L_51:
+  stloc.2
+  leave _cxqt
+L_52:
+L_50:
+  ret
+.try L_27 to L_28 catch ['mscorlib']'System'.'Exception' handler L_51 to L_52
+_cxqt:
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "output"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_53:
+L_54:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  ldarg.0
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(string)
+  leave L_55
+L_55:
+L_56:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Flush'()
+  leave L_57
+L_57:
+  ret
+L_59:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "flushOut"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_60:
+L_58:
+  ret
+.try L_56 to L_57 catch ['mscorlib']'System'.'Exception' handler L_59 to L_60
+L_62:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "output"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_63:
+L_61:
+  ret
+.try L_54 to L_55 catch ['mscorlib']'System'.'Exception' handler L_62 to L_63
+{.locals ([0] bool /*cxrg cxra cxqr*/ ,
+         [1] int32 /*'CharVector.stop'*/ ,
+         [2] class ['mscorlib']'System'.'Exception' /*cxrn cxrq cxre cxrk cxrl cxrh cxri cxrb cxqu*/ ,
+         [3] int32 /*cxrm cxrj cxqz*/ ,
+         [4] char /*cxrf*/ )}
+}
+.method static assembly void 'Regression4.testInt'() cil {
+.maxstack 3
+.zeroinit
+  ldc.i4.s -2147483648
+  ldc.i4.1
+  sub.ovf
+  stloc.0
+  ldstr bytearray (52 00 75 00 6E 00 6E 00 69 00 6E 00 67 00 20 00 49 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldstr bytearray (52 00 75 00 6E 00 6E 00 69 00 6E 00 67 00 20 00 4A 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldc.i4.2
+  ldc.i4.s -2
+  mul.ovf
+  stloc.1
+  ldc.i4.1
+  ldc.i4.s -1
+  ceq
+  stloc.2
+  ldloc.2
+  brtrue L_64
+  ldc.i4.2
+  ldc.i4.s -2
+  sub.ovf
+  stloc.3
+  ldloc.3
+  ldc.i4.s -1
+  add.ovf
+  stloc.3
+  ldloc.3
+  ldc.i4.s -2
+  div
+  stloc.3
+  br _cxrx
+L_64:
+  ldc.i4.s -1
+  stloc.3
+_cxrx:
+  ldc.i4.2
+  neg
+  stloc.s 4
+  ldloc.0
+  call string '$'.'Globals'::'$cxno'(int32)
+  stloc.s 5
+  ldstr "I: "
+  ldloc.s 5
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 5
+  ldloc.s 5
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 5
+  ldloc.s 5
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldloc.s 4
+  call string '$'.'Globals'::'$cxno'(int32)
+  stloc.s 5
+  ldstr "J: "
+  ldloc.s 5
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 5
+  ldloc.s 5
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 5
+  ldloc.s 5
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldloc.1
+  call string '$'.'Globals'::'$cxno'(int32)
+  stloc.s 5
+  ldstr "K: "
+  ldloc.s 5
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 5
+  ldloc.s 5
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 5
+  ldloc.s 5
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldloc.3
+  call string '$'.'Globals'::'$cxno'(int32)
+  stloc.s 5
+  ldstr "L: "
+  ldloc.s 5
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 5
+  ldloc.s 5
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 5
+  ldloc.s 5
+  tail.
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ret
+{.locals ([0] int32 /*cxru*/ ,
+         [1] int32 /*'Regression4.k'*/ ,
+         [2] bool /*cxrw*/ ,
+         [3] int32 /*'Regression4.l' cxsn cxsm 'Regression4.l'*/ ,
+         [4] int32 /*cxrz*/ ,
+         [5] string /*cxsl cxsk cxsj cxsi cxsh cxsg cxsf cxse cxsd cxsc cxsb cxsa*/ )}
+}
+.method static assembly void 'Regression4.testLong'() cil {
+.maxstack 3
+.zeroinit
+  ldstr bytearray (52 00 75 00 6E 00 6E 00 69 00 6E 00 67 00 20 00 49 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldstr bytearray (52 00 75 00 6E 00 6E 00 69 00 6E 00 67 00 20 00 4A 00 0A 00 )
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldc.i8 0x0000000000000001
+  ldc.i8 0xffffffffffffffff
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_65
+  ldc.i8 0xffffffffffffffff
+  stloc.1
+  br _cxsr
+L_65:
+  ldc.i8 0xffffffffffffffff
+  stloc.1
+_cxsr:
+  ldc.i8 0x0000000000000002
+  neg
+  stloc.2
+  ldc.i8 0xffffffffffffffff
+  call string '$'.'Globals'::'$cxoq'(int64)
+  stloc.3
+  ldstr "I: "
+  ldloc.3
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.3
+  ldloc.3
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.3
+  ldloc.3
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldloc.2
+  call string '$'.'Globals'::'$cxoq'(int64)
+  stloc.3
+  ldstr "J: "
+  ldloc.3
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.3
+  ldloc.3
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.3
+  ldloc.3
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldc.i8 0xfffffffffffffffc
+  call string '$'.'Globals'::'$cxoq'(int64)
+  stloc.3
+  ldstr "K: "
+  ldloc.3
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.3
+  ldloc.3
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.3
+  ldloc.3
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldloc.1
+  call string '$'.'Globals'::'$cxoq'(int64)
+  stloc.3
+  ldstr "L: "
+  ldloc.3
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.3
+  ldloc.3
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.3
+  ldloc.3
+  tail.
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ret
+{.locals ([0] bool /*cxsq*/ ,
+         [1] int64 /*'Regression4.l'*/ ,
+         [2] int64 /*cxst*/ ,
+         [3] string /*cxtf cxte cxtd cxtc cxtb cxta cxsz cxsy cxsx cxsw cxsv cxsu*/ )}
+}
+
+}
+}

--- a/test/Regression4.il.expected
+++ b/test/Regression4.il.expected
@@ -101,9 +101,9 @@
 L_1:
   ldloc.0
   ret
-{.locals ([0] string /*cxmq 'PrimUtils_.prefix'*/ ,
-         [1] string /*cxmo*/ ,
-         [2] bool /*cxud*/ )}
+{.locals ([0] string /*cxwp 'PrimUtils_.prefix'*/ ,
+         [1] string /*cxwn*/ ,
+         [2] bool /*cyej*/ )}
 }
 .method public virtual instance string 'ExnMessage'() cil {
 .maxstack 2
@@ -124,8 +124,8 @@ L_1:
   stloc.0
   ldloc.0
   ret
-{.locals ([0] string /*cxmw cxmu cxmt*/ ,
-         [1] string /*cxmv*/ )}
+{.locals ([0] string /*cxwv cxwt cxws*/ ,
+         [1] string /*cxwu*/ )}
 }
 .method public virtual instance string 'ExnName'() cil {
 .maxstack 1
@@ -177,7 +177,7 @@ L_1:
   ret
 {.locals ()}
 }
-.method public static int64 'J\047'(int64 'cxtl') cil {
+.method public static int64 'J\047'(int64 'cydr') cil {
 .maxstack 1
 .zeroinit
   ldarg.0
@@ -189,7 +189,7 @@ L_1:
   ret
 {.locals ()}
 }
-.method public static int64 'I\047'(int64 'cxto') cil {
+.method public static int64 'I\047'(int64 'cydu') cil {
 .maxstack 2
 .zeroinit
   ldarg.0
@@ -202,7 +202,7 @@ L_1:
   ret
 {.locals ()}
 }
-.method public static int32 'J'(int32 'cxtr') cil {
+.method public static int32 'J'(int32 'cydx') cil {
 .maxstack 1
 .zeroinit
   ldarg.0
@@ -214,7 +214,7 @@ L_1:
   ret
 {.locals ()}
 }
-.method public static int32 'I'(int32 'cxtu') cil {
+.method public static int32 'I'(int32 'cyea') cil {
 .maxstack 2
 .zeroinit
   ldarg.0
@@ -373,15 +373,15 @@ L_1:
 
 .field static assembly string '$l'
 .field static assembly int32 '$g'
-.field static assembly class ['mscorlib']'System'.'Exception' '$cxmc'
-.field static assembly string '$cxqf'
-.field static assembly int32 '$cxql'
-.field static assembly class ['mscorlib']'System'.'IO'.'TextWriter' '$cxqo'
+.field static assembly class ['mscorlib']'System'.'Exception' '$cxwb'
+.field static assembly string '$cyae'
+.field static assembly int32 '$cyak'
+.field static assembly class ['mscorlib']'System'.'IO'.'TextWriter' '$cyan'
 .method static assembly void '.cctor'() cil {
 .maxstack 3
 .zeroinit
   newobj instance void '!'.'PrimUtils_'.'Char'.'Chr'::.ctor()
-  stsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cxmc'
+  stsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cxwb'
   ldc.i4.s 11
   conv.u4
   stloc.0
@@ -428,18 +428,18 @@ L_1:
   add.ovf
   pop
   call string ['mscorlib']'System'.'Environment'::'get_NewLine'()
-  stsfld string '$'.'Globals'::'$cxqf'
-  ldsfld string '$'.'Globals'::'$cxqf'
+  stsfld string '$'.'Globals'::'$cyae'
+  ldsfld string '$'.'Globals'::'$cyae'
   ldnull
   ceq
   stloc.3
   ldloc.3
   brtrue L_69
-  ldsfld string '$'.'Globals'::'$cxqf'
+  ldsfld string '$'.'Globals'::'$cyae'
   ldc.i4.s -2147483648
   callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
   stloc.s 4
-  ldsfld string '$'.'Globals'::'$cxqf'
+  ldsfld string '$'.'Globals'::'$cyae'
   callvirt instance int32 ['mscorlib']'System'.'String'::'get_Length'()
   stloc.1
   ldloc.1
@@ -456,43 +456,43 @@ L_1:
   ldloc.s 4
   ldc.i4.s -1
   ldc.i4.1
-  stsfld int32 '$'.'Globals'::'$cxql'
+  stsfld int32 '$'.'Globals'::'$cyak'
   pop
   pop
-  br _cxqk
+  br _cyaj
 L_66:
   ldc.i4.s -1
   ldc.i4.s -1
   ldc.i4.s -2147483648
-  stsfld int32 '$'.'Globals'::'$cxql'
+  stsfld int32 '$'.'Globals'::'$cyak'
   pop
   pop
-  br _cxqk
+  br _cyaj
 L_67:
   ldc.i4.2
   bne.un L_68
-  ldsfld string '$'.'Globals'::'$cxqf'
+  ldsfld string '$'.'Globals'::'$cyae'
   ldc.i4.1
   callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
   stloc.s 5
   ldloc.s 4
   ldloc.s 5
   ldc.i4.2
-  stsfld int32 '$'.'Globals'::'$cxql'
+  stsfld int32 '$'.'Globals'::'$cyak'
   pop
   pop
-  br _cxqk
+  br _cyaj
 L_68:
   ldstr " at TextIO:125.26-79"
   stsfld string '$'.'Globals'::'$l'
   ldstr "Unexpected line separator length"
   newobj instance void '!'.'General'.'Fail'::.ctor(string)
   throw
-_cxqk:
+_cyaj:
   call class ['mscorlib']'System'.'IO'.'TextReader' ['mscorlib']'System'.'Console'::'get_In'()
   pop
   call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Out'()
-  stsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  stsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cyan'
   call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Error'()
   pop
   ret
@@ -502,12 +502,12 @@ L_69:
   ldstr "No line separator available"
   newobj instance void '!'.'General'.'Fail'::.ctor(string)
   throw
-{.locals ([0] unsigned int32 /*cxpz cxpw*/ ,
-         [1] int32 /*cxqj 'Real.eoffset' cxqa cxpy cxpx*/ ,
-         [2] int32 /*cxqe 'Real.large_precision' 'Real.meoffset'*/ ,
-         [3] bool /*cxtw cxuc*/ ,
+{.locals ([0] unsigned int32 /*cxzy cxzv*/ ,
+         [1] int32 /*cyai 'Real.eoffset' cxzz cxzx cxzw*/ ,
+         [2] int32 /*cyad 'Real.large_precision' 'Real.meoffset'*/ ,
+         [3] bool /*cyec cyei*/ ,
          [4] char /*'TextIO.c'*/ ,
-         [5] char /*cxtx*/ )}
+         [5] char /*cyed*/ )}
 }
 .method static assembly void '$'() cil {
 .maxstack 0
@@ -521,7 +521,7 @@ L_69:
   ret
 {.locals ()}
 }
-.method static assembly char 'PrimUtils_.chr'(int32 'cxmf') cil {
+.method static assembly char 'PrimUtils_.chr'(int32 'cxwe') cil {
 .maxstack 3
 .zeroinit
   ldarg.0
@@ -541,16 +541,16 @@ L_69:
 L_2:
   ldstr " at PrimUtils_:579.9-18"
   stsfld string '$'.'Globals'::'$l'
-  ldsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cxmc'
+  ldsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cxwb'
   throw
 L_3:
   ldstr " at PrimUtils_:579.9-18"
   stsfld string '$'.'Globals'::'$l'
-  ldsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cxmc'
+  ldsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cxwb'
   throw
-{.locals ([0] bool /*cxmh cxmg*/ )}
+{.locals ([0] bool /*cxwg cxwf*/ )}
 }
-.method static assembly string 'Utils_.implode'(class '$'.'Tuple2_a' 'cxna') cil {
+.method static assembly string 'Utils_.implode'(class '$'.'Tuple2_a' 'cxwz') cil {
 .maxstack 3
 .zeroinit
   ldarg.0
@@ -568,8 +568,8 @@ L_3:
   brtrue L_5
   newobj instance void ['mscorlib']'System'.'Text'.'StringBuilder'::.ctor()
   stloc.1
-_cxnf:
-_cxng:
+_cxxe:
+_cxxf:
   ldarg.0
   ldnull
   ceq
@@ -584,7 +584,7 @@ _cxng:
   ldarg.0
   ldfld class '$'.'Tuple2_a' '$'.'Tuple2_a'::'_2'
   starg.s 0
-  br _cxng
+  br _cxxf
 L_4:
   ldloc.1
   callvirt instance string ['mscorlib']'System'.'Text'.'StringBuilder'::'ToString'()
@@ -601,11 +601,11 @@ L_5:
 L_6:
   ldstr ""
   ret
-{.locals ([0] bool /*cxtz cxua cxub*/ ,
+{.locals ([0] bool /*cyef cyeg cyeh*/ ,
          [1] class ['mscorlib']'System'.'Text'.'StringBuilder' /*'Utils_.sb'*/ ,
-         [2] string /*cxnn cxnl*/ )}
+         [2] string /*cxxm cxxk*/ )}
 }
-.method static assembly string '$cxno'(int32 'cxnp') cil {
+.method static assembly string '$cxxn'(int32 'cxxo') cil {
 .maxstack 3
 .zeroinit
   ldarg.0
@@ -622,12 +622,12 @@ L_6:
   ldnull
   stloc.1
   starg.s 0
-  br _cxnr
+  br _cxxq
 L_13:
   ldstr "0"
   ret
-_cxnr:
-_cxns:
+_cxxq:
+_cxxr:
   ldarg.0
   ldc.i4.s -2147483648
   ceq
@@ -658,12 +658,12 @@ _cxns:
   stloc.2
   ldloc.2
   brtrue L_8
-  br _cxoa
+  br _cxxz
 L_8:
   ldarg.0
   neg
   starg.s 0
-_cxoa:
+_cxxz:
   ldarg.0
   ldc.i4.s 10
   clt
@@ -687,7 +687,7 @@ _cxoa:
   newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
   stloc.1
   starg.s 0
-  br _cxns
+  br _cxxr
 L_7:
   ldc.i4 48
   ldarg.0
@@ -702,7 +702,7 @@ L_7:
   newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
   stloc.1
   starg.s 0
-  br _cxns
+  br _cxxr
 L_9:
   ldarg.0
   ldc.i4.s 10
@@ -714,12 +714,12 @@ L_9:
   stloc.2
   ldloc.2
   brtrue L_10
-  br _cxns
+  br _cxxr
 L_10:
   ldarg.0
   neg
   starg.s 0
-  br _cxns
+  br _cxxr
 L_11:
   ldloc.0
   brtrue L_12
@@ -735,13 +735,13 @@ L_12:
   call string '$'.'Globals'::'Utils_.implode'(class '$'.'Tuple2_a')
   ret
 {.locals ([0] bool /*'Utils_.negative'*/ ,
-         [1] class '$'.'Tuple2_a' /*cxnt*/ ,
-         [2] bool /*cxop cxom cxoc cxnz cxnw cxnv*/ ,
-         [3] int32 /*cxnx*/ ,
-         [4] int32 /*cxod*/ ,
-         [5] char /*cxoi cxof*/ )}
+         [1] class '$'.'Tuple2_a' /*cxxs*/ ,
+         [2] bool /*cxyo cxyl cxyb cxxy cxxv cxxu*/ ,
+         [3] int32 /*cxxw*/ ,
+         [4] int32 /*cxyc*/ ,
+         [5] char /*cxyh cxye*/ )}
 }
-.method static assembly string '$cxoq'(int64 'cxor') cil {
+.method static assembly string '$cxyp'(int64 'cxyq') cil {
 .maxstack 3
 .zeroinit
   ldc.i4.s 10
@@ -761,12 +761,12 @@ L_12:
   ldnull
   stloc.2
   starg.s 0
-  br _cxou
+  br _cxyt
 L_20:
   ldstr "0"
   ret
-_cxou:
-_cxov:
+_cxyt:
+_cxyu:
   ldarg.0
   ldc.i8 0x0000000000000000
   ceq
@@ -797,12 +797,12 @@ _cxov:
   stloc.3
   ldloc.3
   brtrue L_15
-  br _cxpd
+  br _cxzc
 L_15:
   ldarg.0
   neg
   starg.s 0
-_cxpd:
+_cxzc:
   ldarg.0
   conv.ovf.i4
   stloc.s 5
@@ -832,7 +832,7 @@ _cxpd:
   newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
   stloc.2
   starg.s 0
-  br _cxov
+  br _cxyu
 L_14:
   ldarg.0
   conv.ovf.i4
@@ -850,7 +850,7 @@ L_14:
   newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
   stloc.2
   starg.s 0
-  br _cxov
+  br _cxyu
 L_16:
   ldarg.0
   ldloc.0
@@ -862,12 +862,12 @@ L_16:
   stloc.3
   ldloc.3
   brtrue L_17
-  br _cxov
+  br _cxyu
 L_17:
   ldarg.0
   neg
   starg.s 0
-  br _cxov
+  br _cxyu
 L_18:
   ldloc.1
   brtrue L_19
@@ -884,17 +884,17 @@ L_19:
   ret
 {.locals ([0] int64 /*'Utils_.base'*/ ,
          [1] bool /*'Utils_.negative'*/ ,
-         [2] class '$'.'Tuple2_a' /*cxow*/ ,
-         [3] bool /*cxpv cxps cxpg cxpc cxoz cxoy*/ ,
-         [4] int64 /*cxpa*/ ,
-         [5] int32 /*cxpn cxpm cxpj cxph cxpf*/ ,
-         [6] int32 /*cxpi*/ ,
-         [7] char /*cxpo cxpk*/ )}
+         [2] class '$'.'Tuple2_a' /*cxyv*/ ,
+         [3] bool /*cxzu cxzr cxzf cxzb cxyy cxyx*/ ,
+         [4] int64 /*cxyz*/ ,
+         [5] int32 /*cxzm cxzl cxzi cxzg cxze*/ ,
+         [6] int32 /*cxzh*/ ,
+         [7] char /*cxzn cxzj*/ )}
 }
-.method static assembly void 'TextIO.print'(string 'cxqq') cil {
+.method static assembly void 'TextIO.print'(string 'cyap') cil {
 .maxstack 3
 .zeroinit
-  ldsfld int32 '$'.'Globals'::'$cxql'
+  ldsfld int32 '$'.'Globals'::'$cyak'
   ldc.i4.s -2147483648
   ceq
   stloc.0
@@ -905,8 +905,8 @@ L_19:
   stloc.1
   ldc.i4.s -2147483648
   stloc.3
-_cxqx:
-_cxqy:
+_cyaw:
+_cyax:
   ldloc.3
   ldloc.1
   clt
@@ -914,7 +914,7 @@ _cxqy:
   ldloc.0
   brtrue L_26
 L_21:
-  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cyan'
   callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Flush'()
   leave L_22
 L_22:
@@ -948,7 +948,7 @@ L_28:
   ldloc.0
   brtrue L_39
 L_29:
-  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cyan'
   ldloc.s 4
   callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(char)
   leave L_30
@@ -960,25 +960,25 @@ L_31:
   stloc.3
   leave L_32
 L_32:
-  br _cxqy
+  br _cyax
 L_34:
   stloc.2
-  leave _cxqt
+  leave _cyas
 L_35:
 L_33:
   ret
 .try L_31 to L_32 catch ['mscorlib']'System'.'Exception' handler L_34 to L_35
 L_37:
   stloc.2
-  leave _cxqt
+  leave _cyas
 L_38:
 L_36:
   ret
 .try L_29 to L_30 catch ['mscorlib']'System'.'Exception' handler L_37 to L_38
 L_39:
 L_40:
-  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
-  ldsfld string '$'.'Globals'::'$cxqf'
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cyan'
+  ldsfld string '$'.'Globals'::'$cyae'
   callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(string)
   leave L_41
 L_41:
@@ -989,29 +989,29 @@ L_42:
   stloc.3
   leave L_43
 L_43:
-  br _cxqy
+  br _cyax
 L_45:
   stloc.2
-  leave _cxqt
+  leave _cyas
 L_46:
 L_44:
   ret
 .try L_42 to L_43 catch ['mscorlib']'System'.'Exception' handler L_45 to L_46
 L_48:
   stloc.2
-  leave _cxqt
+  leave _cyas
 L_49:
 L_47:
   ret
 .try L_40 to L_41 catch ['mscorlib']'System'.'Exception' handler L_48 to L_49
 L_51:
   stloc.2
-  leave _cxqt
+  leave _cyas
 L_52:
 L_50:
   ret
 .try L_27 to L_28 catch ['mscorlib']'System'.'Exception' handler L_51 to L_52
-_cxqt:
+_cyas:
   ldstr " at TextIO:87.8-91.12"
   stsfld string '$'.'Globals'::'$l'
   ldstr "TextWriter"
@@ -1022,13 +1022,13 @@ _cxqt:
   throw
 L_53:
 L_54:
-  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cyan'
   ldarg.0
   callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(string)
   leave L_55
 L_55:
 L_56:
-  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cxqo'
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cyan'
   callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Flush'()
   leave L_57
 L_57:
@@ -1061,11 +1061,11 @@ L_63:
 L_61:
   ret
 .try L_54 to L_55 catch ['mscorlib']'System'.'Exception' handler L_62 to L_63
-{.locals ([0] bool /*cxrg cxra cxqr*/ ,
+{.locals ([0] bool /*cybf cyaz cyaq*/ ,
          [1] int32 /*'CharVector.stop'*/ ,
-         [2] class ['mscorlib']'System'.'Exception' /*cxrn cxrq cxre cxrk cxrl cxrh cxri cxrb cxqu*/ ,
-         [3] int32 /*cxrm cxrj cxqz*/ ,
-         [4] char /*cxrf*/ )}
+         [2] class ['mscorlib']'System'.'Exception' /*cybm cybp cybd cybj cybk cybg cybh cyba cyat*/ ,
+         [3] int32 /*cybl cybi cyay*/ ,
+         [4] char /*cybe*/ )}
 }
 .method static assembly void 'Regression4.testInt'() cil {
 .maxstack 3
@@ -1076,98 +1076,116 @@ L_61:
   stloc.0
   ldstr bytearray (52 00 75 00 6E 00 6E 00 69 00 6E 00 67 00 20 00 49 00 0A 00 )
   call void '$'.'Globals'::'TextIO.print'(string)
+  ldc.i4.s -2147483648
+  ldc.i4.1
+  sub.ovf
+  stloc.1
   ldstr bytearray (52 00 75 00 6E 00 6E 00 69 00 6E 00 67 00 20 00 4A 00 0A 00 )
   call void '$'.'Globals'::'TextIO.print'(string)
   ldc.i4.2
   ldc.i4.s -2
   mul.ovf
-  stloc.1
+  stloc.2
   ldc.i4.1
   ldc.i4.s -1
   ceq
-  stloc.2
-  ldloc.2
+  stloc.3
+  ldloc.3
   brtrue L_64
   ldc.i4.2
-  ldc.i4.s -2
+  ldc.i4.s -1
   sub.ovf
-  stloc.3
-  ldloc.3
+  stloc.s 4
+  ldloc.s 4
   ldc.i4.s -1
   add.ovf
-  stloc.3
-  ldloc.3
-  ldc.i4.s -2
-  div
-  stloc.3
-  br _cxrx
-L_64:
+  stloc.s 4
+  ldloc.s 4
   ldc.i4.s -1
-  stloc.3
-_cxrx:
+  div
+  stloc.s 4
+  br _cybx
+L_64:
+  ldc.i4.s -2
+  stloc.s 4
+_cybx:
   ldc.i4.2
   neg
-  stloc.s 4
+  stloc.s 5
   ldloc.0
-  call string '$'.'Globals'::'$cxno'(int32)
-  stloc.s 5
+  call string '$'.'Globals'::'$cxxn'(int32)
+  stloc.s 6
   ldstr "I: "
-  ldloc.s 5
+  ldloc.s 6
   call string ['mscorlib']'System'.'String'::'Concat'(string,string)
-  stloc.s 5
-  ldloc.s 5
+  stloc.s 6
+  ldloc.s 6
   ldstr bytearray (0A 00 )
   call string ['mscorlib']'System'.'String'::'Concat'(string,string)
-  stloc.s 5
-  ldloc.s 5
-  call void '$'.'Globals'::'TextIO.print'(string)
-  ldloc.s 4
-  call string '$'.'Globals'::'$cxno'(int32)
-  stloc.s 5
-  ldstr "J: "
-  ldloc.s 5
-  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
-  stloc.s 5
-  ldloc.s 5
-  ldstr bytearray (0A 00 )
-  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
-  stloc.s 5
-  ldloc.s 5
+  stloc.s 6
+  ldloc.s 6
   call void '$'.'Globals'::'TextIO.print'(string)
   ldloc.1
-  call string '$'.'Globals'::'$cxno'(int32)
-  stloc.s 5
-  ldstr "K: "
-  ldloc.s 5
+  call string '$'.'Globals'::'$cxxn'(int32)
+  stloc.s 6
+  ldstr "I': "
+  ldloc.s 6
   call string ['mscorlib']'System'.'String'::'Concat'(string,string)
-  stloc.s 5
-  ldloc.s 5
+  stloc.s 6
+  ldloc.s 6
   ldstr bytearray (0A 00 )
   call string ['mscorlib']'System'.'String'::'Concat'(string,string)
-  stloc.s 5
-  ldloc.s 5
+  stloc.s 6
+  ldloc.s 6
   call void '$'.'Globals'::'TextIO.print'(string)
-  ldloc.3
-  call string '$'.'Globals'::'$cxno'(int32)
-  stloc.s 5
-  ldstr "L: "
   ldloc.s 5
+  call string '$'.'Globals'::'$cxxn'(int32)
+  stloc.s 6
+  ldstr "J: "
+  ldloc.s 6
   call string ['mscorlib']'System'.'String'::'Concat'(string,string)
-  stloc.s 5
-  ldloc.s 5
+  stloc.s 6
+  ldloc.s 6
   ldstr bytearray (0A 00 )
   call string ['mscorlib']'System'.'String'::'Concat'(string,string)
-  stloc.s 5
-  ldloc.s 5
+  stloc.s 6
+  ldloc.s 6
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldloc.2
+  call string '$'.'Globals'::'$cxxn'(int32)
+  stloc.s 6
+  ldstr "K: "
+  ldloc.s 6
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 6
+  ldloc.s 6
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 6
+  ldloc.s 6
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldloc.s 4
+  call string '$'.'Globals'::'$cxxn'(int32)
+  stloc.s 6
+  ldstr "L: "
+  ldloc.s 6
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 6
+  ldloc.s 6
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 6
+  ldloc.s 6
   tail.
   call void '$'.'Globals'::'TextIO.print'(string)
   ret
-{.locals ([0] int32 /*cxru*/ ,
-         [1] int32 /*'Regression4.k'*/ ,
-         [2] bool /*cxrw*/ ,
-         [3] int32 /*'Regression4.l' cxsn cxsm 'Regression4.l'*/ ,
-         [4] int32 /*cxrz*/ ,
-         [5] string /*cxsl cxsk cxsj cxsi cxsh cxsg cxsf cxse cxsd cxsc cxsb cxsa*/ )}
+{.locals ([0] int32 /*cybt*/ ,
+         [1] int32 /*'Regression4.i\047'*/ ,
+         [2] int32 /*'Regression4.k'*/ ,
+         [3] bool /*cybw*/ ,
+         [4] int32 /*'Regression4.l' cycq cycp 'Regression4.l'*/ ,
+         [5] int32 /*cybz*/ ,
+         [6] string /*cyco cycn cycm cycl cyck cycj cyci cych cycg cycf cyce cycd cycc cycb cyca*/ )}
 }
 .method static assembly void 'Regression4.testLong'() cil {
 .maxstack 3
@@ -1182,18 +1200,18 @@ _cxrx:
   stloc.0
   ldloc.0
   brtrue L_65
-  ldc.i8 0xffffffffffffffff
+  ldc.i8 0xfffffffffffffffe
   stloc.1
-  br _cxsr
+  br _cycu
 L_65:
-  ldc.i8 0xffffffffffffffff
+  ldc.i8 0xfffffffffffffffe
   stloc.1
-_cxsr:
+_cycu:
   ldc.i8 0x0000000000000002
   neg
   stloc.2
   ldc.i8 0xffffffffffffffff
-  call string '$'.'Globals'::'$cxoq'(int64)
+  call string '$'.'Globals'::'$cxyp'(int64)
   stloc.3
   ldstr "I: "
   ldloc.3
@@ -1205,8 +1223,21 @@ _cxsr:
   stloc.3
   ldloc.3
   call void '$'.'Globals'::'TextIO.print'(string)
+  ldc.i8 0xffffffffffffffff
+  call string '$'.'Globals'::'$cxyp'(int64)
+  stloc.3
+  ldstr "I': "
+  ldloc.3
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.3
+  ldloc.3
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.3
+  ldloc.3
+  call void '$'.'Globals'::'TextIO.print'(string)
   ldloc.2
-  call string '$'.'Globals'::'$cxoq'(int64)
+  call string '$'.'Globals'::'$cxyp'(int64)
   stloc.3
   ldstr "J: "
   ldloc.3
@@ -1219,7 +1250,7 @@ _cxsr:
   ldloc.3
   call void '$'.'Globals'::'TextIO.print'(string)
   ldc.i8 0xfffffffffffffffc
-  call string '$'.'Globals'::'$cxoq'(int64)
+  call string '$'.'Globals'::'$cxyp'(int64)
   stloc.3
   ldstr "K: "
   ldloc.3
@@ -1232,7 +1263,7 @@ _cxsr:
   ldloc.3
   call void '$'.'Globals'::'TextIO.print'(string)
   ldloc.1
-  call string '$'.'Globals'::'$cxoq'(int64)
+  call string '$'.'Globals'::'$cxyp'(int64)
   stloc.3
   ldstr "L: "
   ldloc.3
@@ -1246,10 +1277,10 @@ _cxsr:
   tail.
   call void '$'.'Globals'::'TextIO.print'(string)
   ret
-{.locals ([0] bool /*cxsq*/ ,
+{.locals ([0] bool /*cyct*/ ,
          [1] int64 /*'Regression4.l'*/ ,
-         [2] int64 /*cxst*/ ,
-         [3] string /*cxtf cxte cxtd cxtc cxtb cxta cxsz cxsy cxsx cxsw cxsv cxsu*/ )}
+         [2] int64 /*cycw*/ ,
+         [3] string /*cydl cydk cydj cydi cydh cydg cydf cyde cydd cydc cydb cyda cycz cycy cycx*/ )}
 }
 
 }

--- a/test/Regression4.sml
+++ b/test/Regression4.sml
@@ -6,11 +6,13 @@ structure Regression4 = struct
   fun testInt () =
     let
       val i = I 0
+      val i' = 0 - 1
       val j = J 2
       val k = 2 * ~2
-      val l = Int.div (2, ~2)
+      val l = Int.div (2, ~1)
     in
       print ("I: " ^ Int.toString i ^ "\n");
+      print ("I': " ^ Int.toString i' ^ "\n");
       print ("J: " ^ Int.toString j ^ "\n");
       print ("K: " ^ Int.toString k ^ "\n");
       print ("L: " ^ Int.toString l ^ "\n")
@@ -18,11 +20,13 @@ structure Regression4 = struct
   fun testLong () =
     let
       val i: Int64.int = I' 0
+      val i': Int64.int = 0 - 1
       val j: Int64.int = J' 2
       val k: Int64.int = 2 * ~2
-      val l: Int64.int = Int64.div (2, ~2)
+      val l: Int64.int = Int64.div (2, ~1)
     in
       print ("I: " ^ Int64.toString i ^ "\n");
+      print ("I': " ^ Int64.toString i' ^ "\n");
       print ("J: " ^ Int64.toString j ^ "\n");
       print ("K: " ^ Int64.toString k ^ "\n");
       print ("L: " ^ Int64.toString l ^ "\n")

--- a/test/Regression4.sml
+++ b/test/Regression4.sml
@@ -1,0 +1,36 @@
+structure Regression4 = struct
+  fun I i = (i - 1) before print ("Running I\n")
+  fun J j = ~j before print ("Running J\n")
+  fun I' (i: Int64.int) = (i - 1) before print ("Running I\n")
+  fun J' (j: Int64.int) = ~j before print ("Running J\n")
+  fun testInt () =
+    let
+      val i = I 0
+      val j = J 2
+      val k = 2 * ~2
+      val l = Int.div (2, ~2)
+    in
+      print ("I: " ^ Int.toString i ^ "\n");
+      print ("J: " ^ Int.toString j ^ "\n");
+      print ("K: " ^ Int.toString k ^ "\n");
+      print ("L: " ^ Int.toString l ^ "\n")
+    end
+  fun testLong () =
+    let
+      val i: Int64.int = I' 0
+      val j: Int64.int = J' 2
+      val k: Int64.int = 2 * ~2
+      val l: Int64.int = Int64.div (2, ~2)
+    in
+      print ("I: " ^ Int64.toString i ^ "\n");
+      print ("J: " ^ Int64.toString j ^ "\n");
+      print ("K: " ^ Int64.toString k ^ "\n");
+      print ("L: " ^ Int64.toString l ^ "\n")
+    end
+  fun main () =
+    ( print "Testing ints\n"
+    ; testInt ()
+    ; print "Testing longs\n"
+    ; testLong ()
+    )
+end

--- a/test/Regression5.il.expected
+++ b/test/Regression5.il.expected
@@ -1,0 +1,1028 @@
+.assembly extern mscorlib {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 4:0:0:0
+}
+.assembly extern Accessibility {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Configuration.Install {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Data {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.DirectoryServices {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.Drawing {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.EnterpriseServices {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Management {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Messaging {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Runtime.Remoting {
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+.assembly extern System.Runtime.Serialization.Formatters.Soap {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.Security {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern System.ServiceProcess {
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 2:0:0:0
+}
+.assembly extern Mono.Unix {
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )
+  .ver 7:1:0:0
+}
+.assembly 'Regression5'
+{ .hash algorithm 0x00008004 }
+.module 'Regression5.exe'
+
+.namespace '$' {
+.class  private sealed 'Tuple2_a' extends ['mscorlib']'System'.'Object'{
+
+.field assembly char '_1'
+.field assembly class '$'.'Tuple2_a' '_2'
+.method assembly instance void '.ctor'(char '_1',class '$'.'Tuple2_a' '_2') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ldarg.0
+  ldarg.1
+  stfld char '$'.'Tuple2_a'::'_1'
+  ldarg.0
+  ldarg.2
+  stfld class '$'.'Tuple2_a' '$'.'Tuple2_a'::'_2'
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private abstract 'Class_a' extends ['mscorlib']'System'.'Exception'{
+
+.field private initonly string 's'
+.method public instance void '.ctor'(string 's') cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  ldarg.1
+  call instance instance void ['mscorlib']'System'.'Exception'::'.ctor'(string)
+  ldarg.0
+  ldarg.1
+  stfld string '$'.'Class_a'::'s'
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ToString'() cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  callvirt instance string '$'.'Class_a'::'ExnMessage'()
+  stloc.0
+  ldsfld string '$'.'Globals'::'$l'
+  stloc.1
+  ldloc.1
+  ldnull
+  ceq
+  stloc.2
+  ldloc.2
+  brtrue L_13
+  ldloc.0
+  ldloc.1
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldloc.0
+  ret
+L_13:
+  ldloc.0
+  ret
+{.locals ([0] string /*cvet 'PrimUtils_.prefix'*/ ,
+         [1] string /*cver*/ ,
+         [2] bool /*cvkr*/ )}
+}
+.method public virtual instance string 'ExnMessage'() cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  callvirt instance string '$'.'Class_a'::'ExnName'()
+  stloc.0
+  ldloc.0
+  ldstr ": "
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldarg.0
+  callvirt instance string ['mscorlib']'System'.'Exception'::'get_Message'()
+  stloc.1
+  ldloc.0
+  ldloc.1
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.0
+  ldloc.0
+  ret
+{.locals ([0] string /*cvez cvex cvew*/ ,
+         [1] string /*cvey*/ )}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 1
+.zeroinit
+  ldstr "SML exception"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.class  public sealed 'Regression5' extends ['mscorlib']'System'.'Object'{
+
+.method public static void '.cctor'() cil {
+.maxstack 0
+.zeroinit
+  call void '$'.'Globals'::'$'()
+  ret
+{.locals ()}
+}
+.method public static void 'main'() cil {
+.maxstack 3
+.zeroinit
+.entrypoint
+  ldc.i8 0x0000000000001388
+  ldc.i8 0x0000000000001388
+  mul
+  stloc.0
+  ldloc.0
+  ldc.i8 0x0000000000001388
+  mul
+  stloc.0
+  ldc.i8 0x0000000000001388
+  ldc.i8 0x0000000000001388
+  mul
+  stloc.1
+  ldloc.1
+  ldc.i8 0x0000000000001388
+  mul
+  stloc.1
+  ldloc.0
+  ldloc.1
+  add
+  stloc.0
+  ldc.i4.s 16
+  conv.i8
+  stloc.1
+  ldloc.0
+  ldc.i8 0x0000000000000000
+  clt.un
+  stloc.2
+  ldloc.0
+  ldc.i8 0x0000000000000000
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_12
+  ldloc.0
+  ldnull
+  stloc.s 7
+  stloc.s 10
+_cvjn:
+_cvjo:
+  ldloc.s 10
+  ldc.i8 0x0000000000000000
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_10
+  ldloc.s 10
+  ldloc.1
+  div.un
+  pop
+  ldloc.s 10
+  ldc.i8 0x0000000000000000
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_9
+  ldloc.s 10
+  ldloc.1
+  div.un
+  stloc.0
+  ldloc.s 10
+  ldloc.1
+  rem.un
+  stloc.s 11
+  ldloc.s 11
+  conv.ovf.i4.un
+  stloc.s 5
+  ldloc.s 5
+  ldc.i4.s 10
+  clt
+  stloc.3
+  ldloc.3
+  brtrue L_8
+  ldc.i4 65
+  ldc.i4.s 10
+  sub.ovf
+  stloc.s 5
+  ldloc.s 11
+  conv.ovf.i4.un
+  stloc.s 6
+  ldloc.s 5
+  ldloc.s 6
+  add.ovf
+  stloc.s 5
+  ldloc.s 5
+  call char '$'.'Globals'::'PrimUtils_.chr'(int32)
+  stloc.s 9
+  ldloc.0
+  ldloc.s 9
+  ldloc.s 7
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  stloc.s 7
+  stloc.s 10
+  br _cvjo
+L_8:
+  ldloc.s 11
+  conv.ovf.i4.un
+  stloc.s 5
+  ldc.i4 48
+  ldloc.s 5
+  add.ovf
+  stloc.s 5
+  ldloc.s 5
+  call char '$'.'Globals'::'PrimUtils_.chr'(int32)
+  stloc.s 9
+  ldloc.0
+  ldloc.s 9
+  ldloc.s 7
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  stloc.s 7
+  stloc.s 10
+  br _cvjo
+L_9:
+  ldloc.s 10
+  ldloc.1
+  rem.un
+  stloc.0
+  ldloc.0
+  stloc.s 10
+  br _cvjo
+L_10:
+  ldloc.2
+  brtrue L_11
+  ldloc.s 7
+  call string '$'.'Globals'::'Utils_.implode'(class '$'.'Tuple2_a')
+  stloc.s 4
+  br _cvhy
+L_11:
+  ldc.i4 126
+  ldloc.s 7
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  call string '$'.'Globals'::'Utils_.implode'(class '$'.'Tuple2_a')
+  stloc.s 4
+  br _cvhy
+L_12:
+  ldstr "0"
+  stloc.s 4
+_cvhy:
+  ldstr "Word: "
+  ldloc.s 4
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 4
+  ldloc.s 4
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 4
+  ldloc.s 4
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ldc.i4 5000
+  ldc.i4 5000
+  mul.ovf
+  stloc.s 5
+  ldloc.s 5
+  ldc.i4 5000
+  mul.ovf
+  stloc.s 5
+  ldc.i4 5000
+  ldc.i4 5000
+  mul.ovf
+  stloc.s 6
+  ldloc.s 6
+  ldc.i4 5000
+  mul.ovf
+  stloc.s 6
+  ldloc.s 5
+  ldloc.s 6
+  add.ovf
+  stloc.s 5
+  ldloc.s 5
+  ldc.i4.s -2147483648
+  clt
+  stloc.2
+  ldloc.s 5
+  ldc.i4.s -2147483648
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_7
+  ldloc.s 5
+  ldnull
+  stloc.s 7
+  stloc.s 5
+_cvin:
+_cvio:
+  ldloc.s 5
+  ldc.i4.s -2147483648
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_5
+  ldloc.s 5
+  ldc.i4.s 10
+  div
+  pop
+  ldloc.s 5
+  ldc.i4.s -2147483648
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_3
+  ldloc.s 5
+  ldc.i4.s 10
+  div
+  stloc.s 6
+  ldloc.s 5
+  ldc.i4.s 10
+  rem
+  stloc.s 5
+  ldloc.s 5
+  ldc.i4.s -2147483648
+  clt
+  stloc.3
+  ldloc.3
+  brtrue L_2
+  br _cviw
+L_2:
+  ldloc.s 5
+  neg
+  stloc.s 5
+_cviw:
+  ldloc.s 5
+  ldc.i4.s 10
+  clt
+  stloc.3
+  ldloc.3
+  brtrue L_1
+  ldc.i4 65
+  ldc.i4.s 10
+  sub.ovf
+  stloc.s 8
+  ldloc.s 8
+  ldloc.s 5
+  add.ovf
+  stloc.s 5
+  ldloc.s 5
+  call char '$'.'Globals'::'PrimUtils_.chr'(int32)
+  stloc.s 9
+  ldloc.s 6
+  ldloc.s 9
+  ldloc.s 7
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  stloc.s 7
+  stloc.s 5
+  br _cvio
+L_1:
+  ldc.i4 48
+  ldloc.s 5
+  add.ovf
+  stloc.s 5
+  ldloc.s 5
+  call char '$'.'Globals'::'PrimUtils_.chr'(int32)
+  stloc.s 9
+  ldloc.s 6
+  ldloc.s 9
+  ldloc.s 7
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  stloc.s 7
+  stloc.s 5
+  br _cvio
+L_3:
+  ldloc.s 5
+  ldc.i4.s 10
+  rem
+  stloc.s 5
+  ldloc.s 5
+  ldc.i4.s -2147483648
+  clt
+  stloc.3
+  ldloc.3
+  brtrue L_4
+  br _cvio
+L_4:
+  ldloc.s 5
+  neg
+  stloc.s 5
+  br _cvio
+L_5:
+  ldloc.2
+  brtrue L_6
+  ldloc.s 7
+  call string '$'.'Globals'::'Utils_.implode'(class '$'.'Tuple2_a')
+  stloc.s 4
+  br _cvij
+L_6:
+  ldc.i4 126
+  ldloc.s 7
+  newobj instance void '$'.'Tuple2_a'::.ctor(char,class '$'.'Tuple2_a')
+  call string '$'.'Globals'::'Utils_.implode'(class '$'.'Tuple2_a')
+  stloc.s 4
+  br _cvij
+L_7:
+  ldstr "0"
+  stloc.s 4
+_cvij:
+  ldstr "Int: "
+  ldloc.s 4
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 4
+  ldloc.s 4
+  ldstr bytearray (0A 00 )
+  call string ['mscorlib']'System'.'String'::'Concat'(string,string)
+  stloc.s 4
+  ldloc.s 4
+  tail.
+  call void '$'.'Globals'::'TextIO.print'(string)
+  ret
+{.locals ([0] int64 /*cvkg cvjt cvhu cvhr cvhq*/ ,
+         [1] int64 /*cvhv cvht cvhs*/ ,
+         [2] bool /*'Utils_.negative' 'Utils_.negative'*/ ,
+         [3] bool /*cvjw cvjs cvjr cvji cviy cviv cvis cvir cvii cvhx*/ ,
+         [4] string /*cvkj cvkh cvjm cvjk cvim cvil cvik cvib cvia cvhz*/ ,
+         [5] int32 /*cvkd cvkc cvjz cvjx cvjv cvjj cvjh cvjg cvjd cvja cvix cviu cviq 'Regression5.i\047' cvid cvic*/ ,
+         [6] int32 /*cvjy cvit cvif cvie*/ ,
+         [7] class '$'.'Tuple2_a' /*cvjp cvip*/ ,
+         [8] int32 /*cviz*/ ,
+         [9] char /*cvke cvka cvje cvjb*/ ,
+         [10] unsigned int64 /*cvjq*/ ,
+         [11] int64 /*cvju*/ )}
+}
+
+}
+
+.namespace '$' {
+.class  private 'Fun' extends ['mscorlib']'System'.'Object'{
+
+.method assembly instance void '.ctor'() cil {
+.maxstack 2
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private sealed 'Tuple3_a' extends ['mscorlib']'System'.'Object'{
+
+.field assembly string '_1'
+.field assembly class ['mscorlib']'System'.'Exception' '_2'
+.field assembly string '_3'
+.method assembly instance void '.ctor'(string '_1',class ['mscorlib']'System'.'Exception' '_2',string '_3') cil {
+.maxstack 4
+.zeroinit
+  ldarg.0
+  call instance void ['mscorlib']'System'.'Object'::'.ctor'()
+  ldarg.0
+  ldarg.1
+  stfld string '$'.'Tuple3_a'::'_1'
+  ldarg.0
+  ldarg.2
+  stfld class ['mscorlib']'System'.'Exception' '$'.'Tuple3_a'::'_2'
+  ldarg.0
+  ldarg.3
+  stfld string '$'.'Tuple3_a'::'_3'
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'IO' {
+.class  private sealed 'Io' extends '$'.'Class_a'{
+
+.field assembly class '$'.'Tuple3_a' '_1'
+.method assembly instance void '.ctor'(class '$'.'Tuple3_a' '') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldnull
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ldarg.0
+  ldarg.1
+  stfld class '$'.'Tuple3_a' '!'.'IO'.'Io'::'_1'
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "IO.Io"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'PrimUtils_'.'Char' {
+.class  private sealed 'Chr' extends '$'.'Class_a'{
+
+.method assembly instance void '.ctor'() cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldnull
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "PrimUtils_.Char.Chr"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '!'.'General' {
+.class  private sealed 'Fail' extends '$'.'Class_a'{
+
+.method assembly instance void '.ctor'(string '') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldarg.1
+  call instance void '$'.'Class_a'::'.ctor'(string)
+  ret
+{.locals ()}
+}
+.method public virtual instance string 'ExnName'() cil {
+.maxstack 3
+.zeroinit
+  ldstr "General.Fail"
+  ret
+{.locals ()}
+}
+
+}
+}
+
+.namespace '$' {
+.class  private 'Globals' extends ['mscorlib']'System'.'Object'{
+
+.field static assembly string '$l'
+.field static assembly int32 '$g'
+.field static assembly class ['mscorlib']'System'.'Exception' '$cvef'
+.field static assembly string '$cvga'
+.field static assembly int32 '$cvgg'
+.field static assembly class ['mscorlib']'System'.'IO'.'TextWriter' '$cvgj'
+.method static assembly void '.cctor'() cil {
+.maxstack 3
+.zeroinit
+  newobj instance void '!'.'PrimUtils_'.'Char'.'Chr'::.ctor()
+  stsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cvef'
+  ldc.i4.s 11
+  conv.u4
+  stloc.0
+  ldc.i4.1
+  ldloc.0
+  shl
+  stloc.1
+  ldloc.1
+  ldc.i4.1
+  sub.ovf
+  pop
+  ldc.i4.s 11
+  ldc.i4.1
+  sub.ovf
+  stloc.1
+  ldloc.1
+  conv.u4
+  stloc.0
+  ldc.i4.1
+  ldloc.0
+  shl
+  stloc.1
+  ldloc.1
+  ldc.i4.1
+  sub.ovf
+  stloc.1
+  ldloc.1
+  ldc.i4.s 52
+  add.ovf
+  stloc.2
+  ldloc.2
+  ldc.i4.1
+  sub.ovf
+  pop
+  ldc.i8 0x0000000000000040
+  conv.ovf.i4
+  stloc.2
+  ldloc.2
+  ldc.i4.1
+  sub.ovf
+  stloc.2
+  ldloc.2
+  ldloc.1
+  add.ovf
+  pop
+  call string ['mscorlib']'System'.'Environment'::'get_NewLine'()
+  stsfld string '$'.'Globals'::'$cvga'
+  ldsfld string '$'.'Globals'::'$cvga'
+  ldnull
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_65
+  ldsfld string '$'.'Globals'::'$cvga'
+  ldc.i4.s -2147483648
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 4
+  ldsfld string '$'.'Globals'::'$cvga'
+  callvirt instance int32 ['mscorlib']'System'.'String'::'get_Length'()
+  stloc.1
+  ldloc.1
+  dup
+  ldc.i4.1
+  bne.un L_63
+  pop
+  ldloc.s 4
+  ldc.i4 10
+  ceq
+  stloc.3
+  ldloc.3
+  brtrue L_62
+  ldloc.s 4
+  ldc.i4.s -1
+  ldc.i4.1
+  stsfld int32 '$'.'Globals'::'$cvgg'
+  pop
+  pop
+  br _cvgf
+L_62:
+  ldc.i4.s -1
+  ldc.i4.s -1
+  ldc.i4.s -2147483648
+  stsfld int32 '$'.'Globals'::'$cvgg'
+  pop
+  pop
+  br _cvgf
+L_63:
+  ldc.i4.2
+  bne.un L_64
+  ldsfld string '$'.'Globals'::'$cvga'
+  ldc.i4.1
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 5
+  ldloc.s 4
+  ldloc.s 5
+  ldc.i4.2
+  stsfld int32 '$'.'Globals'::'$cvgg'
+  pop
+  pop
+  br _cvgf
+L_64:
+  ldstr " at TextIO:125.26-79"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "Unexpected line separator length"
+  newobj instance void '!'.'General'.'Fail'::.ctor(string)
+  throw
+_cvgf:
+  call class ['mscorlib']'System'.'IO'.'TextReader' ['mscorlib']'System'.'Console'::'get_In'()
+  pop
+  call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Out'()
+  stsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cvgj'
+  call class ['mscorlib']'System'.'IO'.'TextWriter' ['mscorlib']'System'.'Console'::'get_Error'()
+  pop
+  ret
+L_65:
+  ldstr " at TextIO:118.20-68"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "No line separator available"
+  newobj instance void '!'.'General'.'Fail'::.ctor(string)
+  throw
+{.locals ([0] unsigned int32 /*cvfu cvfr*/ ,
+         [1] int32 /*cvge 'Real.eoffset' cvfv cvft cvfs*/ ,
+         [2] int32 /*cvfz 'Real.large_precision' 'Real.meoffset'*/ ,
+         [3] bool /*cvkk cvkq*/ ,
+         [4] char /*'TextIO.c'*/ ,
+         [5] char /*cvkl*/ )}
+}
+.method static assembly void '$'() cil {
+.maxstack 0
+.zeroinit
+  ret
+{.locals ()}
+}
+.method static assembly void '.GCSafePoint'() managed noinlining {
+.maxstack 0
+.zeroinit
+  ret
+{.locals ()}
+}
+.method static assembly char 'PrimUtils_.chr'(int32 'cvei') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldc.i4.s -2147483648
+  clt
+  stloc.0
+  ldloc.0
+  brtrue L_15
+  ldarg.0
+  ldc.i4 65535
+  cgt
+  stloc.0
+  ldloc.0
+  brtrue L_14
+  ldarg.0
+  ret
+L_14:
+  ldstr " at PrimUtils_:579.9-18"
+  stsfld string '$'.'Globals'::'$l'
+  ldsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cvef'
+  throw
+L_15:
+  ldstr " at PrimUtils_:579.9-18"
+  stsfld string '$'.'Globals'::'$l'
+  ldsfld class ['mscorlib']'System'.'Exception' '$'.'Globals'::'$cvef'
+  throw
+{.locals ([0] bool /*cvek cvej*/ )}
+}
+.method static assembly string 'Utils_.implode'(class '$'.'Tuple2_a' 'cvfd') cil {
+.maxstack 3
+.zeroinit
+  ldarg.0
+  ldnull
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_18
+  ldarg.0
+  ldfld class '$'.'Tuple2_a' '$'.'Tuple2_a'::'_2'
+  ldnull
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_17
+  newobj instance void ['mscorlib']'System'.'Text'.'StringBuilder'::.ctor()
+  stloc.1
+_cvfi:
+_cvfj:
+  ldarg.0
+  ldnull
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_16
+  ldloc.1
+  ldarg.0
+  ldfld char '$'.'Tuple2_a'::'_1'
+  callvirt instance class ['mscorlib']'System'.'Text'.'StringBuilder' ['mscorlib']'System'.'Text'.'StringBuilder'::'Append'(char)
+  pop
+  ldarg.0
+  ldfld class '$'.'Tuple2_a' '$'.'Tuple2_a'::'_2'
+  starg.s 0
+  br _cvfj
+L_16:
+  ldloc.1
+  callvirt instance string ['mscorlib']'System'.'Text'.'StringBuilder'::'ToString'()
+  stloc.2
+  ldloc.2
+  ret
+L_17:
+  ldarg.0
+  ldfld char '$'.'Tuple2_a'::'_1'
+  call string ['mscorlib']'System'.'Char'::'ToString'(char)
+  stloc.2
+  ldloc.2
+  ret
+L_18:
+  ldstr ""
+  ret
+{.locals ([0] bool /*cvkn cvko cvkp*/ ,
+         [1] class ['mscorlib']'System'.'Text'.'StringBuilder' /*'Utils_.sb'*/ ,
+         [2] string /*cvfq cvfo*/ )}
+}
+.method static assembly void 'TextIO.print'(string 'cvgl') cil {
+.maxstack 3
+.zeroinit
+  ldsfld int32 '$'.'Globals'::'$cvgg'
+  ldc.i4.s -2147483648
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_51
+  ldarg.0
+  callvirt instance int32 ['mscorlib']'System'.'String'::'get_Length'()
+  stloc.1
+  ldc.i4.s -2147483648
+  stloc.3
+_cvgs:
+_cvgt:
+  ldloc.3
+  ldloc.1
+  clt
+  stloc.0
+  ldloc.0
+  brtrue L_24
+L_19:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cvgj'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Flush'()
+  leave L_20
+L_20:
+  ret
+L_22:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "flushOut"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_23:
+L_21:
+  ret
+.try L_19 to L_20 catch ['mscorlib']'System'.'Exception' handler L_22 to L_23
+L_24:
+L_25:
+  ldarg.0
+  ldloc.3
+  callvirt instance char ['mscorlib']'System'.'String'::'get_Chars'(int32)
+  stloc.s 4
+  leave L_26
+L_26:
+  ldloc.s 4
+  ldc.i4 10
+  ceq
+  stloc.0
+  ldloc.0
+  brtrue L_37
+L_27:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cvgj'
+  ldloc.s 4
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(char)
+  leave L_28
+L_28:
+L_29:
+  ldloc.3
+  ldc.i4.1
+  add.ovf
+  stloc.3
+  leave L_30
+L_30:
+  br _cvgt
+L_32:
+  stloc.2
+  leave _cvgo
+L_33:
+L_31:
+  ret
+.try L_29 to L_30 catch ['mscorlib']'System'.'Exception' handler L_32 to L_33
+L_35:
+  stloc.2
+  leave _cvgo
+L_36:
+L_34:
+  ret
+.try L_27 to L_28 catch ['mscorlib']'System'.'Exception' handler L_35 to L_36
+L_37:
+L_38:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cvgj'
+  ldsfld string '$'.'Globals'::'$cvga'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(string)
+  leave L_39
+L_39:
+L_40:
+  ldloc.3
+  ldc.i4.1
+  add.ovf
+  stloc.3
+  leave L_41
+L_41:
+  br _cvgt
+L_43:
+  stloc.2
+  leave _cvgo
+L_44:
+L_42:
+  ret
+.try L_40 to L_41 catch ['mscorlib']'System'.'Exception' handler L_43 to L_44
+L_46:
+  stloc.2
+  leave _cvgo
+L_47:
+L_45:
+  ret
+.try L_38 to L_39 catch ['mscorlib']'System'.'Exception' handler L_46 to L_47
+L_49:
+  stloc.2
+  leave _cvgo
+L_50:
+L_48:
+  ret
+.try L_25 to L_26 catch ['mscorlib']'System'.'Exception' handler L_49 to L_50
+_cvgo:
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "output"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_51:
+L_52:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cvgj'
+  ldarg.0
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Write'(string)
+  leave L_53
+L_53:
+L_54:
+  ldsfld class ['mscorlib']'System'.'IO'.'TextWriter' '$'.'Globals'::'$cvgj'
+  callvirt instance void ['mscorlib']'System'.'IO'.'TextWriter'::'Flush'()
+  leave L_55
+L_55:
+  ret
+L_57:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "flushOut"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_58:
+L_56:
+  ret
+.try L_54 to L_55 catch ['mscorlib']'System'.'Exception' handler L_57 to L_58
+L_60:
+  stloc.2
+  ldstr " at TextIO:87.8-91.12"
+  stsfld string '$'.'Globals'::'$l'
+  ldstr "TextWriter"
+  ldloc.2
+  ldstr "output"
+  newobj instance void '$'.'Tuple3_a'::.ctor(string,class ['mscorlib']'System'.'Exception',string)
+  newobj instance void '!'.'IO'.'Io'::.ctor(class '$'.'Tuple3_a')
+  throw
+L_61:
+L_59:
+  ret
+.try L_52 to L_53 catch ['mscorlib']'System'.'Exception' handler L_60 to L_61
+{.locals ([0] bool /*cvhb cvgv cvgm*/ ,
+         [1] int32 /*'CharVector.stop'*/ ,
+         [2] class ['mscorlib']'System'.'Exception' /*cvhi cvhl cvgz cvhf cvhg cvhc cvhd cvgw cvgp*/ ,
+         [3] int32 /*cvhh cvhe cvgu*/ ,
+         [4] char /*cvha*/ )}
+}
+
+}
+}

--- a/test/Regression5.sml
+++ b/test/Regression5.sml
@@ -1,0 +1,14 @@
+structure Regression5 = struct
+  fun main () =
+    let
+      (* Doesn't check for overflow for words *)
+      val w: Word64.word = 0w5000
+      val w' = w * w * w + w * w * w
+      val () = print ("Word: " ^ Word64.toString w' ^ "\n");
+      (* Raises overflow for ints *)
+      val i: int = 5000
+      val i' = i * i * i + i * i * i
+    in
+      print ("Int: " ^ Int.toString i' ^ "\n")
+    end
+end

--- a/test/test.sh
+++ b/test/test.sh
@@ -2,14 +2,17 @@ succeeded=0
 failed=0
 for file in *.sml; do
   filename=${file%.*}
-  $SMLNETPATH/bin/smlnet.sh $filename
-  if cmp --silent $filename.il $filename.il.expected; then
-    echo "$filename succeeded"
-    succeeded=$((succeeded+1))
+  if $SMLNETPATH/bin/smlnet.sh $filename; then
+    if cmp --silent $filename.il $filename.il.expected; then
+      echo "$filename succeeded"
+      succeeded=$((succeeded+1))
+    else
+      echo "$filename failed"
+      echo "Diff:"
+      diff $filename.il $filename.il.expected
+      failed=$((failed+1))
+    fi
   else
-    echo "$filename failed"
-    echo "Diff:"
-    diff $filename.il $filename.il.expected
     failed=$((failed+1))
   fi
 done

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,17 @@
+succeeded=0
+failed=0
+for file in *.sml; do
+  filename=${file%.*}
+  $SMLNETPATH/bin/smlnet.sh $filename
+  if cmp --silent $filename.il $filename.il.expected; then
+    echo "$filename succeeded"
+    succeeded=$((succeeded+1))
+  else
+    echo "$filename failed"
+    echo "Diff:"
+    diff $filename.il $filename.il.expected
+    failed=$((failed+1))
+  fi
+done
+
+echo Succeeded: $succeeded Failed: $failed


### PR DESCRIPTION
* Modifies `Deunit` pass to eliminate `:= ()`s, which closes #2 
* Adds basic test suite to try to catch changes in the IR. Running `test.sh` compiles every file and checks if the IR matches the expected IR.
* Reverts integer subtraction and negation numops for RTInt and RTLong because before they were overflowing to a large positive number which was causing `smlfmt` to crash but now that problem doesn't seem to happen now. `smlfmt`, `smlgen`, and all other demos and examples compile and run correctly. If it happens again I should make a test that more closely captures this behavior.